### PR TITLE
Range break continue

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -17,6 +17,7 @@
 package cl
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"syscall"
@@ -354,11 +355,12 @@ func compileForPhrase(parent *blockCtx, f ast.ForPhrase, noExecCtx bool) (*block
 		typVal = typData.Elem()
 		varVal = ctx.insertVar(f.Value.Name, typVal, true).v
 	}
+	brkVal := ctx.insertVar(getBreakVarName(f.For), exec.TyInt, true).v
 	return ctx, func(exprElt func()) {
 		exprX()
 		out := ctx.out
 		c := ctx.NewForPhrase(typData)
-		out.ForPhrase(c, varKey, varVal, !noExecCtx)
+		out.ForPhrase(c, varKey, varVal, brkVal, !noExecCtx)
 		if f.Cond != nil {
 			compileExpr(ctx, f.Cond)()
 			checkBool(ctx.infer.Pop())
@@ -367,6 +369,9 @@ func compileForPhrase(parent *blockCtx, f ast.ForPhrase, noExecCtx bool) (*block
 		exprElt()
 		out.EndForPhrase(c)
 	}
+}
+func getBreakVarName(pos token.Pos) string {
+	return fmt.Sprintf("_gop_break_%d", pos)
 }
 
 func compileForPhrases(ctx *blockCtx, fors []ast.ForPhrase) (*blockCtx, []func(exprElt func())) {

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -14,60 +14,42 @@
  limitations under the License.
 */
 
-package cl
+package cl_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/goplus/gop"
-	"github.com/goplus/gop/ast/asttest"
-	"github.com/goplus/gop/parser"
-	"github.com/goplus/gop/token"
-	"github.com/qiniu/x/log"
-
-	exec "github.com/goplus/gop/exec/bytecode"
-	libbuiltin "github.com/goplus/gop/lib/builtin"
+	"github.com/goplus/gop/cl/cltest"
 )
 
 // -----------------------------------------------------------------------------
 
-var fsTestAssign = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var testAssign = `
 	x, y := 123, "Hello"
 	x
 	y
-`)
+`
 
 func TestAssign(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestAssign, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x, y:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-2); v != 123 {
-		t.Fatal("x:", v)
-	}
-	if v := ctx.Get(-1); v != "Hello" {
-		t.Fatal("y:", v)
-	}
+	cltest.Call(t, testAssign).Equal("Hello")
+	cltest.Call(t, testAssign, -2).Equal(123)
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestSwif = asttest.NewSingleFileFS("/foo", "bar.gop", `
+func TestSwitch(t *testing.T) {
+	testScripts(t, "TestSwitch", testSwitchIfScripts)
+}
+
+var testSwitchIfScripts = map[string]testData{
+	"switch_into_case":            {testSwif, []string{"5"}},
+	"switch_into_default":         {fsTestSwif2, []string{"7"}},
+	"switch_into_case_with_cond":  {fsTestSw, []string{"5"}},
+	"switch_into_case_with_empty": {fsTestSw2, []string{"5"}},
+	"switch_with_no_case":         {fsTestSw3, []string{"7"}},
+}
+
+var testSwif = `
 	x := 0
 	t := "Hello"
 	switch {
@@ -78,35 +60,10 @@ var fsTestSwif = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	default:
 		x = 7
 	}
-	x
-`)
+	println(x)
+`
 
-func TestSwitchIf(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestSwif, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 5 {
-		t.Fatal("x:", v)
-	}
-}
-
-// -----------------------------------------------------------------------------
-
-var fsTestSwif2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestSwif2 = `
 	x := 0
 	t := "Hello"
 	switch {
@@ -117,37 +74,10 @@ var fsTestSwif2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	default:
 		x = 7
 	}
-	x
-`)
+	println(x)
+`
 
-func TestSwitchIfDefault(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestSwif2, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	code.Dump(os.Stdout)
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 7 {
-		t.Fatal("x:", v)
-	}
-}
-
-// -----------------------------------------------------------------------------
-
-var fsTestSw = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestSw = `
 	x := 0
 	switch t := "Hello"; t {
 	case "xsw":
@@ -157,35 +87,11 @@ var fsTestSw = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	default:
 		x= 7
 	}
-	x
-`)
+	println(x)
 
-func TestSwitch(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestSw, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
+`
 
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 5 {
-		t.Fatal("x:", v)
-	}
-}
-
-// -----------------------------------------------------------------------------
-
-var fsTestSw2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestSw2 = `
 	x := 0
 	t := "Hello"
 	switch t {
@@ -196,138 +102,52 @@ var fsTestSw2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	case "xsw":
 		x = 3
 	}
-	x
-`)
+	println(x)
+x
+`
 
-func TestSwitch2(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestSw2, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 5 {
-		t.Fatal("x:", v)
-	}
-}
-
-// -----------------------------------------------------------------------------
-
-var fsTestSw3 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestSw3 = `
 	x := 0
 	t := "Hello"
 	switch t {
 	default:
 		x = 7
 	}
-	x
-`)
-
-func TestDefault(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestSw3, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 7 {
-		t.Fatal("x:", v)
-	}
-}
+	println(x)
+`
 
 // -----------------------------------------------------------------------------
 
-var fsTestIf = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var testIfScripts = map[string]testData{
+	"if_with_else":    {fsTestIf, []string{"5"}},
+	"if_without_else": {fsTestIf2, []string{"3"}},
+}
+
+var fsTestIf = `
 	x := 0
 	if t := false; t {
 		x = 3
 	} else {
 		x = 5
 	}
-	x
-`)
+	println(x)
+`
 
-func TestIf(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestIf, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 5 {
-		t.Fatal("x:", v)
-	}
-}
-
-// -----------------------------------------------------------------------------
-
-var fsTestIf2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestIf2 = `
 	x := 5
 	if true {
 		x = 3
 	}
-	x
-`)
+		println(x)
+`
 
-func TestIf2(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestIf2, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("x:", ctx.Get(-1))
-	if v := ctx.Get(-1); v != 3 {
-		t.Fatal("x:", v)
-	}
+func TestIf(t *testing.T) {
+	testScripts(t, "TestIf", testIfScripts)
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestReturn = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestReturn = `
 	import (
 		"fmt"
 		"strings"
@@ -338,37 +158,15 @@ var fsTestReturn = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	}
 
 	fmt.Println(foo("Hello, world???"))
-`)
+`
 
 func TestReturn(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestReturn, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(16) {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestReturn, "Hello, world!!!\n")
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestReturn2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestReturn2 = `
 	func max(a, b int) int {
 		if a < b {
 			a = b
@@ -377,37 +175,15 @@ var fsTestReturn2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	}
 
 	println("max(23,345):", max(23,345))
-`)
+`
 
 func TestReturn2(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestReturn2, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(17) {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestReturn2, "max(23,345): 345\n")
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestFunc = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestFunc = `
 	import "fmt"
 
 	func foo(x string) (n int, err error) {
@@ -416,37 +192,15 @@ var fsTestFunc = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	}
 
 	foo("Hello, world!")
-`)
+`
 
 func TestFunc(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestFunc, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(17) {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestFunc, "x: Hello, world!\n")
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestFuncv = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestFuncv = `
 	import "fmt"
 
 	func foo(format string, args ...interface{}) (n int, err error) {
@@ -460,37 +214,15 @@ var fsTestFuncv = asttest.NewSingleFileFS("/foo", "bar.gop", `
 
 	bar(foo)
 	println(foo("Hello, %v!\n", 123))
-`)
+`
 
 func TestFuncv(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestFuncv, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(9) {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestFuncv, "Hello, glang!\n"+"Hello, 123!\n"+"12 <nil>\n")
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestClosure = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestClosure = `
 	import "fmt"
 
 	foo := func(prompt string) (n int, err error) {
@@ -500,37 +232,15 @@ var fsTestClosure = asttest.NewSingleFileFS("/foo", "bar.gop", `
 
 	x := "Hello, world!"
 	foo("x: ")
-`)
+`
 
 func TestClosure(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestClosure, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(17) {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestClosure, "x: Hello, world!\n")
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestClosurev = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestClosurev = `
 	import "fmt"
 
 	foo := func(format string, args ...interface{}) (n int, err error) {
@@ -539,69 +249,30 @@ var fsTestClosurev = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	}
 
 	foo("Hello, %v!\n", "xsw")
-`)
+`
 
 func TestClosurev(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestClosurev, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
+	cltest.Expect(t, fsTestClosurev, "Hello, xsw!\n")
 
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(12) {
-		t.Fatal("n:", v)
-	}
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestForPhraseStmt = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestForPhraseStmt = `
 	sum := 0
 	for x <- [1, 3, 5, 7, 11, 13, 17], x > 3 {
 		sum += x
 	}
 	sum
-`)
+`
 
 func TestForPhraseStmt(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestForPhraseStmt, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	if v := ctx.Get(-1); v != 53 {
-		t.Fatal("v:", v)
-	}
+	cltest.Call(t, fsTestForPhraseStmt).Equal(53)
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestForPhraseStmt2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestForPhraseStmt2 = `
 	sum := 0
 	for x <- [1, 3, 5, 7, 11, 13, 17] {
 		if x > 3 {
@@ -609,33 +280,15 @@ var fsTestForPhraseStmt2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 		}
 	}
 	sum
-`)
+`
 
 func TestForPhraseStmt2(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestForPhraseStmt2, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	if v := ctx.Get(-1); v != 53 {
-		t.Fatal("v:", v)
-	}
+	cltest.Call(t, fsTestForPhraseStmt2).Equal(53)
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestForPhraseStmt3 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestForPhraseStmt3 = `
 	fns := make([]func() int, 3)
 	for i, x <- [3, 15, 777] {
 		v := x
@@ -644,40 +297,13 @@ var fsTestForPhraseStmt3 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 		}
 	}
 	println("values:", fns[0](), fns[1](), fns[2]())
-`)
+`
 
 func TestForPhraseStmt3(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestForPhraseStmt3, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != 17 {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestForPhraseStmt3, "values: 3 15 777\n")
 }
 
 // -----------------------------------------------------------------------------
-
-type testData struct {
-	clause string
-	wants  []string
-}
 
 var testForRangeClauses = map[string]testData{
 	"no_kv_range_list": {`sum:=0
@@ -725,7 +351,7 @@ var testForRangeClauses = map[string]testData{
 					`, []string{"34"}},
 	"both_kv_range_map": {`sum:=0
 					m:={1:2,2:4,3:8}
-					for k,v:=range m { 
+					for k,v:=range m {
 						//1*2+2*4+3*8=34
 						sum+=k*v
 					}
@@ -793,14 +419,12 @@ var testForRangeClauses = map[string]testData{
 }
 
 func TestRangeStmt(t *testing.T) {
-	for name, clause := range testForRangeClauses {
-		testSingleStmt(name, t, asttest.NewSingleFileFS("/foo", "bar.gop", clause.clause), clause.wants)
-	}
+	testScripts(t, "TestRangeStmt", testForRangeClauses)
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestRangeStmt2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestRangeStmt2 = `
 	sum := 0
 	for _, x := range [1, 3, 5, 7, 11, 13, 17] {
 		if x > 3 {
@@ -808,33 +432,15 @@ var fsTestRangeStmt2 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 		}
 	}
 	sum
-`)
+`
 
 func TestRangeStmt2(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestRangeStmt2, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err, "noExecCtx:", noExecCtx)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	if v := ctx.Get(-1); v != 53 {
-		t.Fatal("v:", v)
-	}
+	cltest.Call(t, fsTestRangeStmt2).Equal(53)
 }
 
 // -----------------------------------------------------------------------------
 
-var fsTestForStmt = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestForStmt = `
 	fns := make([]func() int, 3)
 	arr := [3, 15, 777]
 	sum := 0
@@ -845,32 +451,10 @@ var fsTestForStmt = asttest.NewSingleFileFS("/foo", "bar.gop", `
 		}
 	}
 	println("values:", fns[0](), fns[1](), fns[2]())
-`)
+`
 
 func _TestForStmt(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestForStmt, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != 17 {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestForStmt, "values: 3 15 777\n")
 }
 
 // -----------------------------------------------------------------------------
@@ -944,7 +528,7 @@ var testNormalForClauses = map[string]testData{
 								break L
 							}
 							sum+=arr[i]+arr[j]
-						}	
+						}
 					}
 					println(sum)
 					`, []string{"12"}}, // (1+1)+(1+3)+(1+5)
@@ -958,7 +542,7 @@ var testNormalForClauses = map[string]testData{
 								continue L
 							}
 							sum+=arr[i]+arr[j]
-						}	
+						}
 					}
 					println(sum)
 					`, []string{"48"}}, // (1+3+5+7)*2+(1+3)*4
@@ -1049,7 +633,7 @@ var testNormalForClauses = map[string]testData{
 						for j:=0;j<len(arr);j++{
 							if arr[j]>1{
 								break L1
-							}	
+							}
 							sum+=arr[i]+arr[j]
 						}
 					}
@@ -1067,7 +651,7 @@ var testNormalForClauses = map[string]testData{
 						for j:=0;j<len(arr);j++{
 							if arr[j]>3{
 								break L
-							}	
+							}
 							sum+=arr[i]+arr[j]
 						}
 					}
@@ -1076,92 +660,18 @@ var testNormalForClauses = map[string]testData{
 }
 
 func TestNormalForStmt(t *testing.T) {
-	for name, clause := range testNormalForClauses {
-		testSingleStmt(name, t, asttest.NewSingleFileFS("/foo", "bar.gop", clause.clause), clause.wants)
-	}
+	testScripts(t, "TestNormalForStmt", testNormalForClauses)
 }
 
-func testSingleStmt(name string, t *testing.T, fs *asttest.MemFS, wants []string) {
-	defer func() {
-		if r := recover(); r != nil {
-			if len(wants) > 0 && wants[0] == "_panic" {
-				return
-			}
-			t.Fatal(name, "-", r)
-		}
-	}()
-	var results []string
-	selfPrintln := func(arity int, p *gop.Context) {
-		args := p.GetArgs(arity)
-		results = append(results, fmt.Sprintln(args...))
-		n, err := fmt.Println(args...)
-		p.Ret(arity, n, err)
-	}
-	libbuiltin.I.RegisterFuncvs(libbuiltin.I.Funcv("println", fmt.Print, selfPrintln))
-
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fs, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal(name+" : ParseFSDir failed:", err, len(pkgs))
-	}
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal(name+" :Compile failed:", err)
-	}
-	code := b.Resolve()
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal(name+" :error:", v)
-	}
-	if v := ctx.Get(-2); v != len(results[len(results)-1]) {
-		t.Fatal(name+" :n:", v)
-	}
-	if len(wants) != len(results) {
-		t.Fatal(name+" exec fail , wants", wants, ",actually", results)
-	}
-	for i := 0; i < len(wants); i++ {
-		if wants[i]+"\n" != results[i] {
-			t.Fatal(name+" exec fail", i, "result wants", wants[i], ",actually", results[i])
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-
-var fsTestForIncDecStmt = asttest.NewSingleFileFS("/foo", "bar.gop", `
+var fsTestForIncDecStmt = `
 	a,b:=10,2
 	{a--;a--;a--}
 	{b++;b++;b++}
 	println(a,b,a*b)
-`)
+`
 
 func TestForIncDecStmt(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseFSDir(fset, fsTestForIncDecStmt, "/foo", nil, 0)
-	if err != nil || len(pkgs) != 1 {
-		t.Fatal("ParseFSDir failed:", err, len(pkgs))
-	}
-
-	bar := pkgs["main"]
-	b := exec.NewBuilder(nil)
-	_, noExecCtx, err := newPackage(b, bar, fset)
-	if err != nil || !noExecCtx {
-		t.Fatal("Compile failed:", err)
-	}
-	code := b.Resolve()
-
-	ctx := exec.NewContext(code)
-	ctx.Exec(0, code.Len())
-	fmt.Println("results:", ctx.Get(-2), ctx.Get(-1))
-	if v := ctx.Get(-1); v != nil {
-		t.Fatal("error:", v)
-	}
-	if v := ctx.Get(-2); v != int(7) {
-		t.Fatal("n:", v)
-	}
+	cltest.Expect(t, fsTestForIncDecStmt, "7 5 35\n")
 }
 
 // -----------------------------------------------------------------------------
@@ -1313,13 +823,13 @@ var testSwitchBranchClauses = map[string]testData{
 							}
 							println(x)
 						case 1:
-							println(x)  
-							x++	
+							println(x)
+							x++
 							continue L
 						case 2:
-							println(x)  
+							println(x)
 							x++
-							break 
+							break
 						case 3:
 							println(x)
 							break L
@@ -1330,14 +840,12 @@ var testSwitchBranchClauses = map[string]testData{
 							println(x)
 						}
 					}
-				
+
 					`, []string{"2", "0", "1", "2"}},
 }
 
 func TestSwitchBranchStmt(t *testing.T) {
-	for name, clause := range testSwitchBranchClauses {
-		testSingleStmt(name, t, asttest.NewSingleFileFS("/foo", "bar.gop", clause.clause), clause.wants)
-	}
+	testScripts(t, "TestSwitchBranchStmt", testSwitchBranchClauses)
 }
 
 // -----------------------------------------------------------------------------
@@ -1406,8 +914,345 @@ var testGotoLabelClauses = map[string]testData{
 }
 
 func TestGotoLabelStmt(t *testing.T) {
-	for name, clause := range testGotoLabelClauses {
-		log.Info("===> TestGotoLabelStmt", name)
-		testSingleStmt(name, t, asttest.NewSingleFileFS("/foo", "bar.gop", clause.clause), clause.wants)
-	}
+	testScripts(t, "TestGotoLabelStmt", testGotoLabelClauses)
+}
+
+// -----------------------------------------------------------------------------
+
+var testRangeStmtWithBranchClauses = map[string]testData{
+	"range_with_continue": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i,_:=range arr {
+						if arr[i]<5{
+							continue
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"12"}},
+	"range_with_break": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i,_:=range arr {
+						if arr[i]>5{
+							break
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"9"}},
+	"range_with_break_label": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i,_:=range arr {
+						for j:=0;j<len(arr);j++{
+							if j>2{
+								break L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"12"}}, // (1+1)+(1+3)+(1+5)
+	"range_with_continue_label": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i,_:=range arr {
+						for j:=0;j<len(arr);j++{
+							if j>1{
+								continue L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"48"}}, // (1+3+5+7)*2+(1+3)*4
+	"range_with_continue_break": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i,_:=range arr {
+						if arr[i]>5{
+							break
+						}
+						for j:=0;j<len(arr);j++{
+							if arr[j]<5{
+								continue
+							}
+							sum+=arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"36"}},
+	"range_with_continue_break_continue": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L1:
+					for i,_:=range arr {
+						if arr[i]>5{
+							break
+						}
+						for j:=i;j<len(arr);j++{
+							if arr[j]<5{
+								continue L1
+							}
+							sum+=arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"12"}},
+	"range_with_continue_panic": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i,_:=range arr {
+					}
+					continue
+					println(sum)
+					`, []string{"_panic"}},
+	"range_with_continue_no_label_panic": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i,_:=range arr {
+						continue L
+					}
+					println(sum)
+					`, []string{"_panic"}},
+	"range_with_break_panic": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i,_:=range arr {
+					}
+					break
+					println(sum)
+					`, []string{"_panic"}},
+	"range_with_break_label_panic": {`
+					arr := [1,3,5,7]
+					L:
+					sum := 0
+					for i,_:=range arr {
+						break L
+					}
+					println(sum)
+					`, []string{"_panic"}},
+	"range_with_continue_wrong_label_panic": {`
+					arr := [1,3,5,7]
+					L:
+					sum := 0
+					for i,_:=range arr {
+						continue L
+					}
+					println(sum)
+					`, []string{"_panic"}},
+	"range_with_many_labels": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i,_:=range arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j:=0;j<len(arr);j++{
+							if arr[j]>1{
+								break L1
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"8"}},
+	"range_with_many_labels_break": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i,_:=range arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j,_:=range arr {
+							if arr[j]>3{
+								break L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"18"}},
+}
+
+func TestRangeStmtWithBranch(t *testing.T) {
+	testScripts(t, "TestRangeStmtWithBranch", testRangeStmtWithBranchClauses)
+}
+
+// -----------------------------------------------------------------------------
+
+var testForPhraseWithBranchClauses = map[string]testData{
+	"for_phrase_with_continue": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]<5{
+							continue
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"12"}},
+	"for_phrase_with_break": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]>5{
+							break
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"9"}},
+	"for_phrase_with_break_label": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i, _ <- arr {
+						for j:=0;j<len(arr);j++{
+							if j>2{
+								break L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"12"}}, // (1+1)+(1+3)+(1+5)
+	"for_phrase_with_continue_label": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i, _ <- arr {
+						for j:=0;j<len(arr);j++{
+							if j>1{
+								continue L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"48"}}, // (1+3+5+7)*2+(1+3)*4
+	"for_phrase_with_continue_break": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]>5{
+							break
+						}
+						for j:=0;j<len(arr);j++{
+							if arr[j]<5{
+								continue
+							}
+							sum+=arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"36"}},
+	"for_phrase_with_continue_break_continue": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L1:
+					for i, _ <- arr {
+						if arr[i]>5{
+							break
+						}
+						for j:=i;j<len(arr);j++{
+							if arr[j]<5{
+								continue L1
+							}
+							sum+=arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"12"}},
+	"for_phrase_with_continue_panic": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i, _ <- arr {
+					}
+					continue
+					println(sum)
+					`, []string{"_panic"}},
+	"for_phrase_with_continue_no_label_panic": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i, _ <- arr {
+						continue L
+					}
+					println(sum)
+					`, []string{"_panic"}},
+	"for_phrase_with_break_panic": {`
+					arr := [1,3,5,7]
+					sum := 0
+					for i, _ <- arr {
+					}
+					break
+					println(sum)
+					`, []string{"_panic"}},
+	"for_phrase_with_break_label_panic": {`
+					arr := [1,3,5,7]
+					L:
+					sum := 0
+					for i, _ <- arr {
+						break L
+					}
+					println(sum)
+					`, []string{"_panic"}},
+	"for_phrase_with_continue_wrong_label_panic": {`
+					arr := [1,3,5,7]
+					L:
+					sum := 0
+					for i, _ <- arr {
+						continue L
+					}
+					println(sum)
+					`, []string{"_panic"}},
+	"for_phrase_with_many_labels": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i, _ <- arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j:=0;j<len(arr);j++{
+							if arr[j]>1{
+								break L1
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"8"}},
+	"for_phrase_with_many_labels_break": {`
+					arr := [1,3,5,7]
+					sum := 0
+					L:
+					for i, _ <- arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j, _ <- arr {
+							if arr[j]>3{
+								break L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"18"}},
+}
+
+func TestForPhraseWithBranch(t *testing.T) {
+	testScripts(t, "TestForPhraseWithBranch", testForPhraseWithBranchClauses)
 }

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1256,3 +1256,185 @@ var testForPhraseWithBranchClauses = map[string]testData{
 func TestForPhraseWithBranch(t *testing.T) {
 	testScripts(t, "TestForPhraseWithBranch", testForPhraseWithBranchClauses)
 }
+
+// -----------------------------------------------------------------------------
+
+var testRangeMapWithBranchClauses = map[string]testData{
+	"map_for_with_continue": {`
+					arr := {1:1,2:3,3:5,4:7}
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]<5{
+							continue
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"12"}},
+	"map_for_with_break": {`
+					arr := {1:1,2:3,3:5,4:7}
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]>0{
+							break
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"0"}},
+	"map_for_with_break_label": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						for j:=0;j<len(arr);j++{
+							if j>2{
+								break L
+							}
+							sum+=arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"9"}},
+	"map_for_with_continue_label": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						for j:=0;j<len(arr);j++{
+							if j>1{
+								continue L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"48"}}, // (1+3+5+7)*2+(1+3)*4
+	"map_for_with_many_labels": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j:=0;j<len(arr);j++{
+							if arr[j]>1{
+								break L1
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"8"}},
+	"map_for_range_many_labels_break": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j:=0;j<len(arr);j++{
+							if arr[j]>3{
+								break L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"18"}},
+
+	"map_for_range_continue": {`
+					arr := {1:1,2:3,3:5,4:7}
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]<5{
+							continue
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"12"}},
+	"map_for_range_break": {`
+					arr := {1:1,2:3,3:5,4:7}
+					sum := 0
+					for i, _ <- arr {
+						if arr[i]>0{
+							break
+						}
+						sum+=arr[i]
+					}
+					println(sum)
+					`, []string{"0"}},
+	"map_for_range_break_label": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						for j:=0;j<len(arr);j++{
+							if j>2{
+								break L
+							}
+							sum+=arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"9"}},
+	"map_for_range_continue_label": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						for j:=0;j<len(arr);j++{
+							if j>1{
+								continue L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"48"}}, // (1+3+5+7)*2+(1+3)*4
+	"map_for_range_many_labels": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j:=0;j<len(arr);j++{
+							if arr[j]>1{
+								break L1
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"8"}},
+	"map_for_with_many_labels_break": {`
+					arr := {0:1,1:3,2:5,3:7}
+					sum := 0
+					L:
+					for i, _ <- arr {
+						if arr[i]<7{
+								continue L
+						}
+						L1:
+						for j:=0;j<len(arr);j++{
+							if arr[j]>3{
+								break L
+							}
+							sum+=arr[i]+arr[j]
+						}
+					}
+					println(sum)
+					`, []string{"18"}},
+}
+
+func TestMapForPhraseWithBranch(t *testing.T) {
+	testScripts(t, "TestMapForPhraseWithBranch", testRangeMapWithBranchClauses)
+}

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -203,7 +203,7 @@ type Builder interface {
 	ErrWrap(nret int, retErr Var, frame *errors.Frame, narg int) Builder
 
 	// ForPhrase instr
-	ForPhrase(f ForPhrase, key, val Var, hasExecCtx ...bool) Builder
+	ForPhrase(f ForPhrase, key, val, brk Var, hasExecCtx ...bool) Builder
 
 	// FilterForPhrase instr
 	FilterForPhrase(f ForPhrase) Builder

--- a/exec/bytecode/goinstr.go
+++ b/exec/bytecode/goinstr.go
@@ -99,7 +99,7 @@ func (c *ForPhrase) execListRange(data reflect.Value, ctx *Context) {
 func (c *ForPhrase) execMapRange(data reflect.Value, ctx *Context) {
 	var iter = data.MapRange()
 	var ip, ipCond, ipEnd = ctx.ip, c.Cond, c.End
-	var key, val = c.Key, c.Value
+	var key, val, brk = c.Key, c.Value, c.Brk
 	var blockScope = c.block != nil
 	var old savedScopeCtx
 	for iter.Next() {
@@ -120,6 +120,15 @@ func (c *ForPhrase) execMapRange(data reflect.Value, ctx *Context) {
 			}
 		} else {
 			ctx.Exec(ip, ipEnd)
+		}
+		if brk != nil {
+			blk := ctx.varScope
+			if blockScope {
+				blk = old.varScope
+			}
+			if blk.getVar(brk.idx).(int) == 1 {
+				break
+			}
 		}
 		if blockScope {
 			ctx.restoreScope(old)

--- a/exec/bytecode/goinstr.go
+++ b/exec/bytecode/goinstr.go
@@ -61,6 +61,7 @@ func (c *ForPhrase) execListRange(data reflect.Value, ctx *Context) {
 	var key, val, brk = c.Key, c.Value, c.Brk
 	var blockScope = c.block != nil
 	var old savedScopeCtx
+	var breakNow bool
 	for i := 0; i < n; i++ {
 		if key != nil {
 			ctx.setVar(key.idx, i)
@@ -86,11 +87,14 @@ func (c *ForPhrase) execListRange(data reflect.Value, ctx *Context) {
 				blk = old.varScope
 			}
 			if blk.getVar(brk.idx).(int) == 1 {
-				break
+				breakNow = true
 			}
 		}
 		if blockScope {
 			ctx.restoreScope(old)
+		}
+		if breakNow {
+			break
 		}
 	}
 	ctx.ip = ipEnd
@@ -102,6 +106,7 @@ func (c *ForPhrase) execMapRange(data reflect.Value, ctx *Context) {
 	var key, val, brk = c.Key, c.Value, c.Brk
 	var blockScope = c.block != nil
 	var old savedScopeCtx
+	var breakNow bool
 	for iter.Next() {
 		if key != nil {
 			ctx.setVar(key.idx, iter.Key().Interface())
@@ -127,11 +132,14 @@ func (c *ForPhrase) execMapRange(data reflect.Value, ctx *Context) {
 				blk = old.varScope
 			}
 			if blk.getVar(brk.idx).(int) == 1 {
-				break
+				breakNow = true
 			}
 		}
 		if blockScope {
 			ctx.restoreScope(old)
+		}
+		if breakNow {
+			break
 		}
 	}
 	ctx.ip = ipEnd

--- a/exec/bytecode/goinstr_test.go
+++ b/exec/bytecode/goinstr_test.go
@@ -129,7 +129,7 @@ func TestMapComprehension(t *testing.T) {
 		Push("xsw").
 		Push(1).
 		MakeMap(typData, 2).
-		ForPhrase(f, key, val, true).
+		ForPhrase(f, key, val, nil, true).
 		LoadVar(val).
 		LoadVar(key).
 		EndForPhrase(f).
@@ -156,7 +156,7 @@ func TestMapComprehensionFilter(t *testing.T) {
 		Push("xsw").
 		Push(1).
 		MakeMap(typData, 2).
-		ForPhrase(f, key, val).
+		ForPhrase(f, key, val, nil).
 		LoadVar(val).
 		Push(2).
 		BuiltinOp(Int, OpLE).
@@ -186,7 +186,7 @@ func TestListComprehension(t *testing.T) {
 		Push(5).
 		Push(7).
 		MakeArray(typData, 4).
-		ForPhrase(f, nil, x).
+		ForPhrase(f, nil, x, nil).
 		LoadVar(x).
 		LoadVar(x).
 		BuiltinOp(Int, OpMul).
@@ -213,7 +213,7 @@ func TestListComprehensionFilter(t *testing.T) {
 		Push(5).
 		Push(7).
 		MakeArray(typData, 4).
-		ForPhrase(f, nil, x).
+		ForPhrase(f, nil, x, nil).
 		LoadVar(x).
 		Push(3).
 		BuiltinOp(Int, OpGT). // x > 3
@@ -245,7 +245,7 @@ func TestMapComprehension2(t *testing.T) {
 		Push(5).
 		Push(7).
 		MakeArray(typData, 4).
-		ForPhrase(f, i, x).
+		ForPhrase(f, i, x, nil).
 		LoadVar(x).
 		LoadVar(x).
 		BuiltinOp(Int, OpMul).
@@ -274,13 +274,13 @@ func TestListComprehensionEx(t *testing.T) {
 		Push(6).
 		Push(7).
 		MakeArray(typData, 3).
-		ForPhrase(fb, nil, b).
+		ForPhrase(fb, nil, b, nil).
 		Push(1).
 		Push(2).
 		Push(3).
 		Push(4).
 		MakeArray(typData, 4).
-		ForPhrase(fa, nil, a).
+		ForPhrase(fa, nil, a, nil).
 		LoadVar(a).
 		Push(1).
 		BuiltinOp(Int, OpGT). // a > 1

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -140,8 +140,8 @@ func (p *iBuilder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg 
 }
 
 // ForPhrase instr
-func (p *iBuilder) ForPhrase(f exec.ForPhrase, key, val exec.Var, hasExecCtx ...bool) exec.Builder {
-	((*Builder)(p)).ForPhrase(f.(*ForPhrase), toVar(key), toVar(val), hasExecCtx...)
+func (p *iBuilder) ForPhrase(f exec.ForPhrase, key, val, brk exec.Var, hasExecCtx ...bool) exec.Builder {
+	((*Builder)(p)).ForPhrase(f.(*ForPhrase), toVar(key), toVar(val), toVar(brk), hasExecCtx...)
 	return p
 }
 

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -161,8 +161,8 @@ func (p *iBuilder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg 
 }
 
 // ForPhrase instr
-func (p *iBuilder) ForPhrase(f exec.ForPhrase, key, val exec.Var, hasExecCtx ...bool) exec.Builder {
-	((*Builder)(p)).ForPhrase(f.(*ForPhrase), toVar(key), toVar(val), hasExecCtx...)
+func (p *iBuilder) ForPhrase(f exec.ForPhrase, key, val, brk exec.Var, hasExecCtx ...bool) exec.Builder {
+	((*Builder)(p)).ForPhrase(f.(*ForPhrase), toVar(key), toVar(val), toVar(brk), hasExecCtx...)
 	return p
 }
 

--- a/exec/golang/testdata/12.flow/flow.gop
+++ b/exec/golang/testdata/12.flow/flow.gop
@@ -149,3 +149,19 @@ L4:
 		}
 		println(k, v)
 	}
+
+	mapData := {0: 1, 1: 3, 2: 5, 3: 7}
+	sum := 0
+LM:
+	for i, _ <- mapData {
+		if mapData[i] < 7 {
+			continue LM
+		}
+		for j := 0; j < len(mapData); j++ {
+			if mapData[j] > 3 {
+				break LM
+			}
+			sum += mapData[i] + mapData[j]
+		}
+	}
+	println(sum)

--- a/exec/golang/testdata/12.flow/flow.gop
+++ b/exec/golang/testdata/12.flow/flow.gop
@@ -165,3 +165,12 @@ LM:
 		}
 	}
 	println(sum)
+
+	fns := make([]func() int, 3)
+	for mi, mx <- {0: 3, 1: 15, 2: 777} {
+		mv := mx
+		fns[mi] = func() int {
+			return mv
+		}
+	}
+	println("values:", fns[0](), fns[1](), fns[2]())

--- a/exec/golang/testdata/12.flow/flow.gop
+++ b/exec/golang/testdata/12.flow/flow.gop
@@ -128,3 +128,24 @@ L3:
 			println(x)
 		}
 	}
+
+	for k, v <- [1, 2, 3] {
+		if k < 1 {
+			continue
+		}
+		if k > 1 {
+			break
+		}
+		println(k, v)
+	}
+
+	L4
+	for k, v <- [1, 2, 3] {
+		if k < 1 {
+			continue L4
+		}
+		if k > 1 {
+			break L4
+		}
+		println(k, v)
+	}

--- a/exec/golang/testdata/12.flow/flow.gop
+++ b/exec/golang/testdata/12.flow/flow.gop
@@ -139,7 +139,7 @@ L3:
 		println(k, v)
 	}
 
-	L4
+L4:
 	for k, v <- [1, 2, 3] {
 		if k < 1 {
 			continue L4


### PR DESCRIPTION
bytecode：
在for-body中开始加入brk变量，默认为0；在for-body的结尾增加两个跳转标签，break跳转到label1，continue和正常语句都跳转到label2；label1增加语句将brk赋值为1，label2为空语句。当execForPhrase检测到brk==1时，结束循环。
go code:
和上同逻辑基本相同，只是将label1语句改为break。
```go
for k,v <-[1,2,3]{
	if k<1{
		continue
	}
	if k>1{
		break
	}
	println(k,v)
}
```
转成go代码为
```go
package main

import fmt "fmt"

func main() {
//line ./a.gop:1
	for k, v := range []int{1, 2, 3} {
//line ./a.gop:2
		if !(k < 1) {
			goto _gop_1
		}
//line ./a.gop:3
		goto _gop_continue_27
	_gop_1:
//line ./a.gop:5
		if !(k > 1) {
			goto _gop_2
		}
//line ./a.gop:6
		goto _gop_break_27
	_gop_2:
//line ./a.gop:8
		fmt.Println(k, v)
//line ./a.gop:1
		goto _gop_continue_27
//line ./a.gop:1
		goto _gop_break_27
	_gop_break_27:
		break
//line ./a.gop:1
		goto _gop_continue_27
	_gop_continue_27:
	}
}
```