### PR TITLE
exec,cl : load & store field

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -185,12 +185,21 @@ func checkLabel(fl *flowLabel) bool {
 type blockCtx struct {
 	*pkgCtx
 	*funcCtx
-	file      *fileCtx
-	parent    *blockCtx
-	syms      map[string]iSymbol
-	noExecCtx bool
-	checkFlag bool
-	inLHS     bool
+	file       *fileCtx
+	parent     *blockCtx
+	syms       map[string]iSymbol
+	noExecCtx  bool
+	checkFlag  bool
+	inLHS      bool
+	fieldVar   interface{}
+	fieldIndex []int
+	fieldExprX func()
+}
+
+func (ctx *blockCtx) resetFieldVar(v interface{}) {
+	ctx.fieldVar = v
+	ctx.fieldIndex = nil
+	ctx.fieldExprX = nil
 }
 
 // function block ctx

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -45,6 +45,7 @@ func compileBodyWith(ctx *blockCtx, body []ast.Stmt) {
 }
 
 func compileStmt(ctx *blockCtx, stmt ast.Stmt) {
+	ctx.resetFieldVar(nil)
 	start := ctx.out.StartStmt(stmt)
 	switch v := stmt.(type) {
 	case *ast.ExprStmt:

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -289,6 +289,12 @@ type Builder interface {
 	// AddrGoVar instr
 	AddrGoVar(addr GoVarAddr) Builder
 
+	// LoadField instr
+	LoadField(v interface{}, index []int) Builder
+
+	// StoreField instr
+	StoreField(v interface{}, index []int) Builder
+
 	// AddrOp instr
 	AddrOp(kind Kind, op AddrOperator) Builder
 

--- a/exec/bytecode/code.go
+++ b/exec/bytecode/code.go
@@ -114,6 +114,8 @@ const (
 	opGoBuiltin     = 41 // op(26)
 	opErrWrap       = 42 // idx(26)
 	opWrapIfErr     = 43 // reserved(2) offset(24)
+	opLoadField     = 44
+	opStoreField    = 45
 )
 
 const (
@@ -198,6 +200,8 @@ var instrInfos = []InstrInfo{
 	opGoBuiltin:     {"goBuiltin", "", "op", 26},                          // op(26)
 	opErrWrap:       {"errWrap", "", "idx", 26},                           // idx(26)
 	opWrapIfErr:     {"wrapIfErr", "", "offset", 26},                      // reserved(2) offset(24)
+	opLoadField:     {"loadField", "", "", 26},                            // addr(26)
+	opStoreField:    {"storeField", "", "", 26},                           // addr(26)
 }
 
 // -----------------------------------------------------------------------------

--- a/exec/bytecode/const.go
+++ b/exec/bytecode/const.go
@@ -127,6 +127,8 @@ func (p *Builder) pushInstr(val interface{}) (i Instr) {
 		return iPushFalse
 	} else if kind == reflect.String || (kind >= reflect.Float32 && kind <= reflect.Complex128) {
 		// noop
+	} else if kind == reflect.Slice && v.Type().Elem().Kind() == reflect.Int {
+		// []int
 	} else if !isNilOrRatConst(kind, v) {
 		log.Panicln("Push failed: unsupported type:", reflect.TypeOf(val), "-", val)
 	}

--- a/exec/bytecode/context.go
+++ b/exec/bytecode/context.go
@@ -270,6 +270,8 @@ var _execTable = [...]func(i Instr, p *Context){
 	opGoBuiltin:     execGoBuiltin,
 	opErrWrap:       execErrWrap,
 	opWrapIfErr:     execWrapIfErr,
+	opLoadField:     execLoadField,
+	opStoreField:    execStoreField,
 }
 
 var execTable []func(i Instr, p *Context)

--- a/exec/bytecode/goinstr.go
+++ b/exec/bytecode/goinstr.go
@@ -249,7 +249,11 @@ func execIndex(i Instr, p *Context) {
 	n := len(p.data)
 	v := reflect.Indirect(reflect.ValueOf(p.data[n-1])).Index(idx)
 	if (i & setIndexFlag) != 0 { // value sliceData $idx $setIndex
-		v.Set(reflect.ValueOf(p.data[n-2]))
+		if p.data[n-2] == nil {
+			v.Set(reflect.Zero(v.Type()))
+		} else {
+			v.Set(reflect.ValueOf(p.data[n-2]))
+		}
 		p.PopN(2)
 	} else { // sliceData $idx $setIndex
 		p.data[n-1] = v.Interface()

--- a/exec/bytecode/gopkg.go
+++ b/exec/bytecode/gopkg.go
@@ -63,6 +63,32 @@ func execAddrGoVar(i Instr, p *Context) {
 	p.Push(govars[idx].Addr)
 }
 
+func execLoadField(i Instr, p *Context) {
+	index := p.Pop()
+	v := reflect.ValueOf(p.Pop())
+	v = reflect.Indirect(v)
+	p.Push(v.FieldByIndex(index.([]int)).Interface())
+}
+
+func toElem(v reflect.Value) reflect.Value {
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return v
+}
+
+func execStoreField(i Instr, p *Context) {
+	index := p.Pop()
+	val := p.Pop()
+	value := p.Pop()
+	v := reflect.ValueOf(val)
+	v = toElem(v)
+	if !v.CanSet() {
+		log.Panicf("cannot assign to %v\n", v)
+	}
+	setValue(v.FieldByIndex(index.([]int)), value)
+}
+
 // -----------------------------------------------------------------------------
 
 // A ConstKind represents the specific kind of type that a Type represents.
@@ -390,6 +416,36 @@ func (p *Builder) StoreGoVar(addr GoVarAddr) *Builder {
 func (p *Builder) AddrGoVar(addr GoVarAddr) *Builder {
 	i := (opAddrGoVar << bitsOpShift) | uint32(addr)
 	p.code.data = append(p.code.data, i)
+	return p
+}
+
+// LoadField instr
+func (p *Builder) LoadField(v interface{}, index []int) *Builder {
+	switch x := v.(type) {
+	case exec.GoVarAddr:
+		p.LoadGoVar(x)
+	case *Var:
+		p.LoadVar(x)
+	case reflect.Type:
+	}
+	p.Push(index)
+	i := (opLoadField << bitsOpShift)
+	p.code.data = append(p.code.data, uint32(i))
+	return p
+}
+
+// StoreField instr
+func (p *Builder) StoreField(v interface{}, index []int) *Builder {
+	switch x := v.(type) {
+	case exec.GoVarAddr:
+		p.AddrGoVar(x)
+	case *Var:
+		p.AddrVar(x)
+	case reflect.Type:
+	}
+	p.Push(index)
+	i := (opStoreField << bitsOpShift)
+	p.code.data = append(p.code.data, uint32(i))
 	return p
 }
 

--- a/exec/bytecode/gopkg_test.go
+++ b/exec/bytecode/gopkg_test.go
@@ -173,6 +173,131 @@ func TestGoVar(t *testing.T) {
 	}
 }
 
+type testPoint struct {
+	X int
+	Y int
+}
+
+type testInfo struct {
+	Info string
+}
+
+type testRect struct {
+	testInfo
+	Pt1 testPoint
+	Pt2 *testPoint
+}
+
+var g_Rect *testRect
+
+func init() {
+	g_Rect = &testRect{}
+	g_Rect.Pt2 = &testPoint{}
+}
+
+func getTestRect() *testRect {
+	return g_Rect
+}
+
+func execTestRect(_ int, p *Context) {
+	p.Ret(0, getTestRect())
+}
+
+func TestGoField(t *testing.T) {
+	sprint, ok := I.FindFuncv("Sprint")
+
+	pkg := NewGoPackage("pkg_field")
+
+	rc := testRect{}
+	rc.Info = "Info"
+	rc.Pt1 = testPoint{10, 20}
+	rc.Pt2 = &testPoint{30, 40}
+
+	rc2 := testRect{}
+	rc2.Pt2 = &testPoint{}
+
+	pkg.RegisterVars(
+		pkg.Var("Rect", &rc),
+		pkg.Var("Rect2", &rc2),
+	)
+	pkg.RegisterFuncs(
+		pkg.Func("GetRect", getTestRect, execTestRect),
+	)
+
+	x, ok := pkg.FindVar("Rect")
+	if !ok {
+		t.Fatal("FindVar failed:", x)
+	}
+	x2, ok := pkg.FindVar("Rect2")
+	if !ok {
+		t.Fatal("FindVar failed:", x2)
+	}
+	fnTestRect, ok := pkg.FindFunc("GetRect")
+	if !ok {
+		t.Fatal("FindFunc failed:", fnTestRect)
+	}
+
+	it := reflect.TypeOf(rc)
+	it2 := reflect.TypeOf(g_Rect)
+
+	y := NewVar(it, "y")
+	b := newBuilder()
+
+	code := b.
+		DefineVar(y). // y
+		LoadGoVar(x2).
+		StoreVar(y). // y = pkg_field.Rect2
+		Push("hello").
+		StoreField(x, []int{0, 0}). // pkg_field.Rect.Info = "hello"
+		Push(-1).
+		StoreField(x, []int{1, 0}). // pkg_field.Rect.Pt1.X = -1
+		Push(-2).
+		StoreField(x, []int{2, 1}). // pkg_field.Rect.Pt2.Y = -2
+		Push("world").
+		StoreField(y, []int{0, 0}). // y.Info = "world"
+		Push(-10).
+		StoreField(y, []int{1, 0}). // y.Pt1.X = -10
+		Push(-20).
+		StoreField(y, []int{2, 1}). // y.Pt2.Y = -20
+		Push("next").
+		CallGoFunc(fnTestRect, 0).
+		StoreField(it2, []int{0, 0}). // pkg_field.GetRect().Info = "next"
+		Push(101).
+		CallGoFunc(fnTestRect, 0).
+		StoreField(it2, []int{1, 0}). // pkg_field.GetRect().Pt1.X = 101
+		Push(102).
+		CallGoFunc(fnTestRect, 0).
+		StoreField(it2, []int{2, 1}). // pkg_field.GetRect().Pt2.Y = 102
+		LoadVar(y).
+		StoreGoVar(x2). // pkg_field.Rect2 = y
+		LoadField(x, []int{0, 0}).
+		LoadField(x, []int{2, 1}).
+		LoadField(y, []int{0, 0}).
+		LoadField(y, []int{2, 1}).
+		CallGoFunc(fnTestRect, 0).
+		LoadField(it2, []int{0, 0}).
+		CallGoFunc(fnTestRect, 0).
+		LoadField(it2, []int{2, 1}).
+		CallGoFuncv(sprint, 6, 6). // print(pkg_field.Info,pkg_field.Pt2.Y,y.Info,y.Pt2.Y,pkg_field.GetRect().Info,pkg_field.GetRect().Pt2.Y)
+		Resolve()
+
+	ctx := NewContext(code)
+	ctx.Exec(0, code.Len())
+
+	if rc.Info != "hello" || rc.Pt1.X != -1 || rc.Pt2.Y != -2 {
+		t.Fatal("Rect", rc)
+	}
+	if rc2.Info != "world" || rc2.Pt1.X != -10 || rc2.Pt2.Y != -20 {
+		t.Fatal("Rect2", rc2)
+	}
+	if g_Rect.Info != "next" || g_Rect.Pt1.X != 101 || g_Rect.Pt2.Y != 102 {
+		t.Fatal("g_Rect", g_Rect)
+	}
+	if v := ctx.Get(-1); v != "hello-2world-20next102" {
+		t.Fatal("LoadField", v)
+	}
+}
+
 func TestSprint(t *testing.T) {
 	sprint, ok := I.FindFuncv("Sprint")
 	if !ok {

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -313,6 +313,18 @@ func (p *iBuilder) AddrGoVar(addr GoVarAddr) exec.Builder {
 	return p
 }
 
+// LoadField instr
+func (p *iBuilder) LoadField(v interface{}, index []int) exec.Builder {
+	((*Builder)(p)).LoadField(v, index)
+	return p
+}
+
+// StoreField instr
+func (p *iBuilder) StoreField(v interface{}, index []int) exec.Builder {
+	((*Builder)(p)).StoreField(v, index)
+	return p
+}
+
 // AddrOp instr
 func (p *iBuilder) AddrOp(kind exec.Kind, op exec.AddrOperator) exec.Builder {
 	((*Builder)(p)).AddrOp(kind, op)

--- a/exec/bytecode/struct.go
+++ b/exec/bytecode/struct.go
@@ -99,6 +99,13 @@ func (ctx *varScope) setVar(idx uint32, v interface{}) {
 	setValue(x, v)
 }
 
+func (ctx *varScope) setVarField(idx uint32, v interface{}, index interface{}) {
+	x := ctx.vars.Field(int(idx))
+	x = reflect.Indirect(x)
+	field := x.FieldByIndex(index.([]int))
+	setValue(field, v)
+}
+
 func setValue(x reflect.Value, v interface{}) {
 	if v != nil {
 		x.Set(reflect.ValueOf(v))

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -232,6 +232,11 @@ func (p *Builder) storeVar(addr tAddress) *Builder {
 	return p
 }
 
+// StoreVarField instr
+func (p *Builder) storeVarField(addr tAddress, index []int) *Builder {
+	return p
+}
+
 // -----------------------------------------------------------------------------
 
 // Var represents a variable.

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -18,6 +18,7 @@ package golang
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/goplus/gop/cl"
@@ -120,6 +121,158 @@ func main() {
 	if codeGen != codeExp {
 		fmt.Println(codeGen)
 		t.Fatal("TestGoVar failed: codeGen != codeExp")
+	}
+}
+
+type testInfo struct {
+	Info string
+}
+
+type testPoint struct {
+	X int
+	Y int
+}
+
+type testRect struct {
+	testInfo
+	Pt1 testPoint
+	Pt2 *testPoint
+}
+
+var g_Rect *testRect
+
+func init() {
+	g_Rect = &testRect{}
+	g_Rect.Pt2 = &testPoint{}
+}
+
+func getTestRect() *testRect {
+	return g_Rect
+}
+
+func execTestRect(_ int, p *qexec.Context) {
+	p.Ret(0, getTestRect())
+}
+
+func TestGoField(t *testing.T) {
+	codeExp := `package main
+
+import (
+	fmt "fmt"
+	pkg_field "pkg_field"
+)
+
+var y golang.testRect
+
+func main() {
+	y = pkg_field.Rect2
+	pkg_field.Rect.Info = "hello"
+	pkg_field.Rect.Pt1.X = -1
+	pkg_field.Rect.Pt2.Y = -2
+	y.Info = "world"
+	y.Pt1.X = -10
+	y.Pt2.Y = -20
+	pkg_field.GetRect().Info = "next"
+	pkg_field.GetRect().Pt1.X = 101
+	pkg_field.GetRect().Pt2.Y = 102
+	pkg_field.Rect2 = y
+	fmt.Println(pkg_field.Rect.Info, pkg_field.Rect.Pt2.Y, y.Info, y.Pt2.Y, pkg_field.GetRect().Info, pkg_field.GetRect().Pt2.Y)
+}
+`
+	println, _ := I.FindFuncv("println")
+
+	pkg := qexec.NewGoPackage("pkg_field")
+
+	rc := testRect{}
+	rc.Info = "Info"
+	rc.Pt1 = testPoint{10, 20}
+	rc.Pt2 = &testPoint{30, 40}
+
+	rc2 := testRect{}
+	rc2.Pt2 = &testPoint{}
+
+	pkg.RegisterVars(
+		pkg.Var("Rect", &rc),
+		pkg.Var("Rect2", &rc2),
+	)
+	pkg.RegisterFuncs(
+		pkg.Func("GetRect", getTestRect, execTestRect),
+	)
+
+	x, ok := pkg.FindVar("Rect")
+	if !ok {
+		t.Fatal("FindVar failed:", x)
+	}
+	x2, ok := pkg.FindVar("Rect2")
+	if !ok {
+		t.Fatal("FindVar failed:", x2)
+	}
+	fnTestRect, ok := pkg.FindFunc("GetRect")
+	if !ok {
+		t.Fatal("FindFunc failed:", fnTestRect)
+	}
+
+	it := reflect.TypeOf(rc)
+	it2 := reflect.TypeOf(g_Rect)
+
+	y := NewVar(it, "y")
+
+	b := NewBuilder("main", nil, nil)
+
+	code := b.Interface().
+		DefineVar(y). // y
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		LoadGoVar(x2).
+		StoreVar(y). // y = pkg_field.Rect2
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push("hello").
+		StoreField(x, []int{0, 0}). // pkg_field.Rect.Info = "hello"
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push(-1).
+		StoreField(x, []int{1, 0}). // pkg_field.Rect.Pt1.X = -1
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push(-2).
+		StoreField(x, []int{2, 1}). // pkg_field.Rect.Pt2.Y = -2
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push("world").
+		StoreField(y, []int{0, 0}). // y.Info = "world"
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push(-10).
+		StoreField(y, []int{1, 0}). // y.Pt1.X = -10
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push(-20).
+		StoreField(y, []int{2, 1}). // y.Pt2.Y = -20
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push("next").
+		CallGoFunc(fnTestRect, 0).
+		StoreField(it2, []int{0, 0}). // pkg_field.GetRect().Info = "next"
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push(101).
+		CallGoFunc(fnTestRect, 0).
+		StoreField(it2, []int{1, 0}). // pkg_field.GetRect().Pt1.X = 101
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Push(102).
+		CallGoFunc(fnTestRect, 0).
+		StoreField(it2, []int{2, 1}). // pkg_field.GetRect().Pt2.Y = 102
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		LoadVar(y).
+		StoreGoVar(x2). // pkg_field.Rect2 = y
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		LoadField(x, []int{0, 0}).
+		LoadField(x, []int{2, 1}).
+		LoadField(y, []int{0, 0}).
+		LoadField(y, []int{2, 1}).
+		CallGoFunc(fnTestRect, 0).
+		LoadField(it2, []int{0, 0}).
+		CallGoFunc(fnTestRect, 0).
+		LoadField(it2, []int{2, 1}).
+		CallGoFuncv(println, 6, 6). // print(pkg_field.Info,pkg_field.Pt2.Y,y.Info,y.Pt2.Y,pkg_field.GetRect().Info,pkg_field.GetRect().Pt2.Y)
+		EndStmt(nil, &stmtState{rhsBase: 0}).
+		Resolve()
+
+	if v := code.(*Code); v.String() != codeExp {
+		fmt.Println(v.String())
+		log.Fatal("TestGoVar failed: codeGen != codeExp")
 	}
 }
 

--- a/exec/golang/expr.go
+++ b/exec/golang/expr.go
@@ -425,6 +425,51 @@ func (p *Builder) AddrGoVar(addr exec.GoVarAddr) *Builder {
 	return p
 }
 
+func (p *Builder) fieldExpr(v interface{}, index []int) ast.Expr {
+	var typ reflect.Type
+	expr := &ast.SelectorExpr{}
+	switch x := v.(type) {
+	case exec.GoVarAddr:
+		gvi := defaultImpl.GetGoVarInfo(x)
+		typ = reflect.TypeOf(gvi.This).Elem()
+		expr.X = p.GoSymIdent(gvi.Pkg.PkgPath(), gvi.Name)
+	case exec.Var:
+		typ = x.Type()
+		expr.X = Ident(x.Name())
+	case reflect.Type:
+		typ = x
+		expr.X = p.rhs.Pop().(ast.Expr)
+	}
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	for i := 0; i < len(index); i++ {
+		sf := typ.FieldByIndex(index[:i+1])
+		if sf.Anonymous {
+			continue
+		}
+		if expr.Sel != nil {
+			expr.X = &ast.SelectorExpr{expr.X, expr.Sel}
+		}
+		expr.Sel = Ident(sf.Name)
+	}
+	return expr
+}
+
+// LoadField instr
+func (p *Builder) LoadField(v interface{}, index []int) *Builder {
+	expr := p.fieldExpr(v, index)
+	p.rhs.Push(expr)
+	return p
+}
+
+// StoreField instr
+func (p *Builder) StoreField(v interface{}, index []int) *Builder {
+	expr := p.fieldExpr(v, index)
+	p.lhs.Push(expr)
+	return p
+}
+
 // Append instr
 func (p *Builder) Append(typ reflect.Type, arity int) *Builder {
 	p.rhs.Push(appendIdent)

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -328,6 +328,18 @@ func (p *iBuilder) AddrGoVar(addr exec.GoVarAddr) exec.Builder {
 	return p
 }
 
+// LoadField instr
+func (p *iBuilder) LoadField(v interface{}, index []int) exec.Builder {
+	((*Builder)(p)).LoadField(v, index)
+	return p
+}
+
+// StoreField instr
+func (p *iBuilder) StoreField(v interface{}, index []int) exec.Builder {
+	((*Builder)(p)).StoreField(v, index)
+	return p
+}
+
 // AddrOp instr
 func (p *iBuilder) AddrOp(kind exec.Kind, op exec.AddrOperator) exec.Builder {
 	((*Builder)(p)).AddrOp(kind, op)


### PR DESCRIPTION
尝试实现一个 field 读写的方案，以供检查方向是否正确。目前对 slice/array 未做支持。

在 blockCtx 中加入 field 对应的 var 和 index，通过 reflect.FieldByIndex(index []int) 对结构体的 Field 进行读写。

fieldVar   interface{} // var or reflect.Type
fieldIndex []int         // field index
fieldExprX func() // 在 compileSelectorExpr中记录上一个生成 var/type 时所用函数，以解决 BinaryExpr 时指令顺序问题
resetFieldVar(v interface{}) //重置 field var

其中， fieldVar 包括以下三种类型
exec.Var 在 gop 中定义的变量 v := image.ZP
exec.GoVarAddr 从 go pkg 中导入的变量 build.Default.Dir
reflect.Type 由函数生成，只包含类型，如 image.NewAlpha(image.Rect(0, 0, 2, 2)) // 对应 *image.Alpha 类型

加入新的指令

LoadField(v interface{}, index []int) Builder
StoreField(v interface{}, index []int) Builder