### PR TITLE
support goroutine

### DIFF
--- a/cl/ctx_check.go
+++ b/cl/ctx_check.go
@@ -80,6 +80,8 @@ func isNoExecCtxStmt(ctx *blockCtx, stmt ast.Stmt) bool {
 		return true
 	case *ast.DeferStmt:
 		return isNoExecCtxCallExpr(ctx, v.Call)
+	case *ast.GoStmt:
+		return isNoExecCtxCallExpr(ctx, v.Call)
 	default:
 		log.Panicln("isNoExecCtxStmt failed: unknown -", reflect.TypeOf(v))
 	}

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -73,6 +73,8 @@ func compileStmt(ctx *blockCtx, stmt ast.Stmt) {
 		compileLabeledStmt(ctx, v)
 	case *ast.DeferStmt:
 		compileDeferStmt(ctx, v)
+	case *ast.GoStmt:
+		compileGoStmt(ctx, v)
 	case *ast.EmptyStmt:
 		// do nothing
 	default:
@@ -318,6 +320,95 @@ func compileDeferStmt(ctx *blockCtx, v *ast.DeferStmt) {
 
 	out.Label(end)
 	instr.Set(out, out.Defer(start, end))
+}
+
+func compileGoStmt(ctx *blockCtx, v *ast.GoStmt) {
+	var instr exec.Reserved
+	out := ctx.out
+	start := ctx.NewLabel("")
+	end := ctx.NewLabel("")
+
+	var f func()
+	exprFun := compileExpr(ctx, v.Call.Fun)
+	fn := ctx.infer.Pop()
+	switch vfn := fn.(type) {
+	case *qlFunc:
+		ret := vfn.Results()
+		ctx.infer.Push(ret)
+
+		for _, arg := range v.Call.Args {
+			compileExpr(ctx, arg)()
+		}
+		instr = ctx.out.Reserve()
+		out.Label(start)
+		f = func() {
+			arity := checkFuncCall(vfn.Proto(), 0, v.Call, ctx)
+			fun := vfn.FuncInfo()
+			if fun.IsVariadic() {
+				ctx.out.CallFuncv(fun, len(v.Call.Args), arity)
+			} else {
+				ctx.out.CallFunc(fun, len(v.Call.Args))
+			}
+		}
+	case *goFunc:
+		ret := vfn.Results()
+		ctx.infer.Push(ret)
+
+		for _, arg := range v.Call.Args {
+			compileExpr(ctx, arg)()
+		}
+		instr = ctx.out.Reserve()
+		out.Label(start)
+		f = func() {
+			if vfn.isMethod != 0 {
+				compileExpr(ctx, v.Call.Fun.(*ast.SelectorExpr).X)()
+			}
+			nexpr := len(v.Call.Args) + vfn.isMethod
+			arity := checkFuncCall(vfn.Proto(), vfn.isMethod, v.Call, ctx)
+			switch vfn.kind {
+			case exec.SymbolFunc:
+				ctx.out.CallGoFunc(exec.GoFuncAddr(vfn.addr), nexpr)
+			case exec.SymbolFuncv:
+				ctx.out.CallGoFuncv(exec.GoFuncvAddr(vfn.addr), nexpr, arity)
+			}
+		}
+	case *goValue:
+		if vfn.t.Kind() != reflect.Func {
+			log.Panicln("compileCallExpr failed: call a non function.")
+		}
+		ret := newFuncResults(vfn.t)
+		ctx.infer.Push(ret)
+
+		for _, arg := range v.Call.Args {
+			compileExpr(ctx, arg)()
+		}
+		instr = ctx.out.Reserve()
+		out.Label(start)
+		f = func() {
+			exprFun()
+			arity, ellipsis := checkFuncCall(vfn.t, 0, v.Call, ctx), false
+			if arity == -1 {
+				arity, ellipsis = len(v.Call.Args), true
+			}
+			ctx.out.CallGoClosure(len(v.Call.Args), arity, ellipsis)
+		}
+	case *nonValue:
+		instr = ctx.out.Reserve()
+		out.Label(start)
+		// TODO compile args before compileCallExpr
+		switch nv := vfn.v.(type) {
+		case goInstr:
+			f = nv(ctx, v.Call)
+		case reflect.Type:
+			f = compileTypeCast(nv, ctx, v.Call)
+		}
+	}
+
+	f()
+	ctx.infer.Pop()
+
+	out.Label(end)
+	instr.Set(out, out.Goroutine(start, end))
 }
 
 func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1305,3 +1305,22 @@ var testDeferClauses = map[string]testData{
 func TestDeferStmt(t *testing.T) {
 	testScripts(t, "TestDeferStmt", testDeferClauses)
 }
+
+var testGoroutineClauses = map[string]testData{
+	"goroutine_func": {clause: `
+	go println("hello goroutine")
+	println("test world")
+	`, want: "test world\n"},
+	"goroutine_func1": {clause: `
+		import (
+			"time"
+		)
+		go println("hello goroutine")
+		println("test world")
+		time.Sleep(1 * time.Second)
+		`, want: "test world\nhello goroutine\n"},
+}
+
+func TestGoroutineStmt(t *testing.T) {
+	testScripts(t, "TestGoroutineStmt", testGoroutineClauses)
+}

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -363,6 +363,9 @@ type Builder interface {
 
 	// Defer instr
 	Defer(start, end Label) Instr
+
+	// Goroutine instr
+	Goroutine(start, end Label) Instr
 }
 
 // Package represents a Go+ package.

--- a/exec/bytecode/code.go
+++ b/exec/bytecode/code.go
@@ -115,6 +115,7 @@ const (
 	opErrWrap       = 42 // idx(26)
 	opWrapIfErr     = 43 // reserved(2) offset(24)
 	opDeferOp       = 44 // reserved(2) offset(24)
+	opGoroutineOp   = 45 // reserved(2) offset(24)
 )
 
 const (

--- a/exec/bytecode/context.go
+++ b/exec/bytecode/context.go
@@ -187,6 +187,8 @@ func (ctx *Context) Exec(ip, ipEnd int) {
 			execBuiltinOp(i, ctx)
 		case opDeferOp:
 			execDeferOp(i, ctx)
+		case opGoroutineOp:
+			execGoroutineOp(i, ctx)
 		case opCallFunc:
 			fun := ctx.code.funs[i&bitsOperand]
 			fun.exec(ctx, ctx.getScope(fun.nestDepth > 1))

--- a/exec/bytecode/goroutine.go
+++ b/exec/bytecode/goroutine.go
@@ -1,0 +1,54 @@
+/*
+ Copyright 2020 The GoPlus Authors (goplus.org)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package bytecode implements a bytecode backend for the Go+ language.
+package bytecode
+
+import (
+	"github.com/goplus/gop/exec.spec"
+)
+
+const (
+	bitsOpGoroutine        = bitsOp + 2
+	bitsOpGoroutineOperand = bitsOpGoroutine - 1
+)
+
+func execGoroutineOp(i Instr, p *Context) {
+	end := i & bitsOpGoroutineOperand << bitsOpGoroutine >> bitsOpGoroutine
+
+	data := p.Stack.data
+
+	ctx := newSimpleContext(data)
+	ctx.base = p.base
+	ctx.code = p.code
+	ctx.code.data = ctx.code.data[p.ip : p.ip+int(end)]
+	go ctx.Exec(0, ctx.code.Len())
+	p.ip += int(end)
+}
+
+func (p *Builder) Goroutine(start, end *Label) exec.Instr {
+	return &iGoroutine{start: p.labels[start], end: p.labels[end]}
+}
+
+type iGoroutine struct {
+	start int
+	end   int
+}
+
+func (c *iGoroutine) Val() interface{} {
+	instr := opGoroutineOp<<bitsOpShift | uint32(c.end-c.start)&bitsOpGoroutineOperand
+	return Instr(instr)
+}

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -127,9 +127,14 @@ func (p *iBuilder) Default() exec.Builder {
 	return p
 }
 
-// Default instr
+// Defer instr
 func (p *iBuilder) Defer(start, end exec.Label) exec.Instr {
 	return ((*Builder)(p)).Defer(start.(*Label), end.(*Label))
+}
+
+// Goroutine instr
+func (p *iBuilder) Goroutine(start, end exec.Label) exec.Instr {
+	return ((*Builder)(p)).Goroutine(start.(*Label), end.(*Label))
 }
 
 // WrapIfErr instr

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -171,7 +171,7 @@ func (p *iBuilder) Defer(start, end exec.Label) exec.Instr {
 	return ((*Builder)(p)).Defer(end.(*Label), end.(*Label))
 }
 
-// Defer instr
+// Goroutine instr
 func (p *iBuilder) Goroutine(start, end exec.Label) exec.Instr {
 	return ((*Builder)(p)).Goroutine(end.(*Label), end.(*Label))
 }

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -171,6 +171,11 @@ func (p *iBuilder) Defer(start, end exec.Label) exec.Instr {
 	return ((*Builder)(p)).Defer(end.(*Label), end.(*Label))
 }
 
+// Defer instr
+func (p *iBuilder) Goroutine(start, end exec.Label) exec.Instr {
+	return ((*Builder)(p)).Goroutine(end.(*Label), end.(*Label))
+}
+
 func toVar(v exec.Var) *Var {
 	if v == nil {
 		return nil

--- a/exec/golang/stmt.go
+++ b/exec/golang/stmt.go
@@ -393,8 +393,14 @@ func (p *Builder) EndComprehension(c *Comprehension) *Builder {
 	return p
 }
 
+// Defer instr
 func (p *Builder) Defer(start, end *Label) exec.Instr {
 	panic("The method defer under the builder of golang is not yet supported")
+}
+
+// Goroutine instr
+func (p *Builder) Goroutine(start, end *Label) exec.Instr {
+	panic("The method Goroutine under the builder of golang is not yet supported")
 }
 
 // ----------------------------------------------------------------------------

--- a/tutorial/23-Goroutine/goroutine.gop
+++ b/tutorial/23-Goroutine/goroutine.gop
@@ -1,0 +1,2 @@
+go println("hello goroutine")
+println("test world")


### PR DESCRIPTION
We should expect to be able to use Go's existing GMP model to implement goroutine scheduling, so I added an instruction, OpGoroutineOp, when the instruction is executed, go native goroutine expression is used to process the asynchronous function exec