### PR TITLE
fix inconsistent command line output for different help info

### DIFF
--- a/cmd/gop/main.go
+++ b/cmd/gop/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	base.CmdName = args[0] // for error messages
 	if args[0] == "help" {
-		help.Help(os.Stdout, args[1:])
+		help.Help(os.Stderr, args[1:])
 		return
 	}
 
@@ -58,7 +58,7 @@ BigCmdLoop:
 					os.Exit(2)
 				}
 				if args[0] == "help" {
-					help.Help(os.Stdout, append(strings.Split(base.CmdName, " "), args[1:]...))
+					help.Help(os.Stderr, append(strings.Split(base.CmdName, " "), args[1:]...))
 					return
 				}
 				base.CmdName += " " + args[0]

--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -21,6 +21,7 @@ package base
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -77,10 +78,15 @@ func (c *Command) Name() string {
 }
 
 // Usage show the command usage.
-func (c *Command) Usage() {
-	fmt.Fprintf(os.Stderr, "%s\n\nUsage: %s\n", c.Short, c.UsageLine)
+func (c *Command) Usage(w io.Writer) {
+	fmt.Fprintf(w, "%s\n\nUsage: %s\n", c.Short, c.UsageLine)
+
+	// restore output of flag
+	defer c.Flag.SetOutput(c.Flag.Output())
+
+	c.Flag.SetOutput(w)
 	c.Flag.PrintDefaults()
-	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(w)
 	os.Exit(2)
 }
 

--- a/cmd/internal/export/export.go
+++ b/cmd/internal/export/export.go
@@ -53,7 +53,7 @@ func init() {
 func runCmd(cmd *base.Command, args []string) {
 	flag.Parse(args)
 	if flag.NArg() < 1 {
-		cmd.Usage()
+		cmd.Usage(os.Stderr)
 		return
 	}
 	var libDir string

--- a/cmd/internal/gengo/go.go
+++ b/cmd/internal/gengo/go.go
@@ -185,7 +185,7 @@ func init() {
 func runCmd(cmd *base.Command, args []string) {
 	flag.Parse(args)
 	if flag.NArg() < 1 {
-		cmd.Usage()
+		cmd.Usage(os.Stderr)
 		return
 	}
 	dir := flag.Arg(0)

--- a/cmd/internal/help/help.go
+++ b/cmd/internal/help/help.go
@@ -41,9 +41,9 @@ Args:
 	}
 
 	if len(cmd.Commands) > 0 {
-		PrintUsage(os.Stdout, cmd)
+		PrintUsage(w, cmd)
 	} else {
-		cmd.Usage()
+		cmd.Usage(w)
 	}
 	// not exit 2: succeeded at 'gop help cmd'.
 	return

--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -53,7 +53,7 @@ func init() {
 func runCmd(cmd *base.Command, args []string) {
 	flag.Parse(args)
 	if flag.NArg() < 1 {
-		cmd.Usage()
+		cmd.Usage(os.Stderr)
 	}
 
 	log.SetFlags(log.Ldefault &^ log.LstdFlags)


### PR DESCRIPTION
`w io.Writer` is not used in `help.Help(w io.Writer, args []string)`, fix by pass `io.Writer` in all associated help info output function