### PR TITLE
cmd: export fix ignore internal import pkg bug

### DIFF
--- a/cmd/internal/export/export.go
+++ b/cmd/internal/export/export.go
@@ -196,11 +196,6 @@ func exportPkg(pkgPath string, srcDir string, goRoot bool) (err error) {
 	if err != nil {
 		return fmt.Errorf("import %q failed: %v", pkgPath, err)
 	}
-	for _, im := range pkg.Imports() {
-		if isIgnorePkg(im.Path()) {
-			return gopkg.ErrIgnore
-		}
-	}
 	var buf bytes.Buffer
 	err = gopkg.ExportPackage(pkg, &buf)
 	if err != nil {

--- a/cmd/internal/export/gopkg/exporter.go
+++ b/cmd/internal/export/gopkg/exporter.go
@@ -244,6 +244,15 @@ func (p *Exporter) fixPkgString(typ string) string {
 	})
 }
 
+func isInternalPkg(pkg string) bool {
+	for _, a := range strings.Split(pkg, "/") {
+		if a == "internal" {
+			return true
+		}
+	}
+	return false
+}
+
 // ExportFunc exports a go function/method.
 func (p *Exporter) ExportFunc(fn *types.Func) error {
 	tfn := fn.Type().(*types.Signature)
@@ -278,6 +287,10 @@ func (p *Exporter) ExportFunc(fn *types.Func) error {
 		typ := tfn.Params().At(i).Type()
 		if named, ok := typ.(*types.Named); ok {
 			if !named.Obj().Exported() && named.String() != "error" {
+				fmt.Println("ignore", fn)
+				return nil
+			}
+			if pkg := named.Obj().Pkg(); pkg != nil && isInternalPkg(pkg.Path()) {
 				fmt.Println("ignore", fn)
 				return nil
 			}

--- a/cmd/internal/export/gopkg/exporter_test.go
+++ b/cmd/internal/export/gopkg/exporter_test.go
@@ -204,6 +204,12 @@ func TestIgnorePkg(t *testing.T) {
 	}
 }
 
+func TestWithoutPkg(t *testing.T) {
+	if withoutPkg("github.com/qiniu/x/log") != "github.com/qiniu/x/log" {
+		t.Fatal()
+	}
+}
+
 func TestBadLooupMod(t *testing.T) {
 	dir, err := LookupMod("github.com/qiniu/x/log2")
 	if err == nil {

--- a/cmd/internal/export/gopkg/exporter_test.go
+++ b/cmd/internal/export/gopkg/exporter_test.go
@@ -197,10 +197,10 @@ func TestLooupMod(t *testing.T) {
 
 func TestIgnorePkg(t *testing.T) {
 	if !isInternalPkg("golang.org/x/tools/internal/span") {
-		t.Fatal("must ignore")
+		t.Fatal("is internal pkg")
 	}
 	if isInternalPkg("golang.org/x/tools") {
-		t.Fatal("not ignore")
+		t.Fatal("not internal pkg")
 	}
 }
 

--- a/cmd/internal/export/gopkg/exporter_test.go
+++ b/cmd/internal/export/gopkg/exporter_test.go
@@ -193,7 +193,15 @@ func TestLooupMod(t *testing.T) {
 	if dir != dir1 {
 		t.Fatal("LookupMod failed:", dir, dir1)
 	}
+}
 
+func TestIgnorePkg(t *testing.T) {
+	if !isInternalPkg("golang.org/x/tools/internal/span") {
+		t.Fatal("must ignore")
+	}
+	if isInternalPkg("golang.org/x/tools") {
+		t.Fatal("not ignore")
+	}
 }
 
 func TestBadLooupMod(t *testing.T) {

--- a/cmd/internal/export/gopkg/exporter_test.go
+++ b/cmd/internal/export/gopkg/exporter_test.go
@@ -135,6 +135,13 @@ func TestExportIo(t *testing.T) {
 	}
 }
 
+func TestExportIoUtil(t *testing.T) {
+	err := Export("io/ioutil", ioutil.Discard)
+	if err != nil {
+		t.Fatal("TestExport failed:", err)
+	}
+}
+
 func TestExportGoTypes(t *testing.T) {
 	err := Export("go/types", ioutil.Discard)
 	if err != nil {


### PR DESCRIPTION
之前在 https://github.com/goplus/gop/pull/507 时判断忽略导出 internal pkg 时引入错误，导制部分库会忽略导出。
现已修复此错误，并改用在函数导出参数时进行 internal pkg 判断。

fix ignore internal pkg export. 
```
qexp golang.org/x/tools@latest/go/packages/packagestest
ignore func (*golang.org/x/tools/go/packages/packagestest.Exported).Mark(name string, r golang.org/x/tools/internal/span.Range)
export "golang.org/x/tools/go/packages/packagestest" success
```