### PR TITLE
cl: fix unbound const int call interface{} convert to int #514

### DIFF
--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -160,6 +160,40 @@ func TestUnbound(t *testing.T) {
 	)
 }
 
+func TestUnboundInt(t *testing.T) {
+	cltest.Expect(t, `
+	import "reflect"
+	printf("%T",100)
+	`,
+		"int",
+	)
+	cltest.Expect(t, `
+	import "reflect"
+	printf("%T",-100)
+	`,
+		"int",
+	)
+}
+
+func TestOverflowsInt(t *testing.T) {
+	cltest.Expect(t, `
+	println(9223372036854775807)
+	`,
+		"9223372036854775807\n",
+	)
+	cltest.Expect(t, `
+	println(-9223372036854775808)
+	`,
+		"-9223372036854775808\n",
+	)
+	cltest.Expect(t, `
+	println(9223372036854775808)
+	`,
+		"",
+		nil,
+	)
+}
+
 func TestPanic(t *testing.T) {
 	cltest.Expect(t,
 		`panic("Helo")`,

--- a/cl/gopkg_test.go
+++ b/cl/gopkg_test.go
@@ -48,8 +48,8 @@ func TestPkgConst(t *testing.T) {
 		{"Int2", qspec.ConstUnboundInt, 1024},
 		{"Int3", qspec.ConstUnboundInt, -10000000},
 		{"Int4", qspec.ConstUnboundInt, 10000000},
-		{"MinInt64", reflect.Int64, int64(math.MinInt64)},
-		{"MaxUint64", reflect.Uint64, uint64(math.MaxUint64)},
+		{"MinInt64", qspec.ConstUnboundInt, math.MinInt64},
+		{"MaxInt64", qspec.ConstUnboundInt, math.MaxInt64},
 		{"Pi", qspec.ConstUnboundFloat, math.Pi},
 		{"Complex", qspec.ConstUnboundComplex, 1 + 2i},
 	}

--- a/cl/value.go
+++ b/cl/value.go
@@ -372,16 +372,19 @@ func kindOf(t reflect.Type) exec.Kind {
 	return kind
 }
 
-func isOverflowsIntByInt64(v int64) bool {
-	if strconv.IntSize == 32 {
+const (
+	intSize = strconv.IntSize
+)
+
+func isOverflowsIntByInt64(v int64, intSize int) bool {
+	if intSize == 32 {
 		return v < int64(math.MinInt32) || v > int64(math.MaxInt32)
-	} else {
-		return v < int64(math.MinInt64) || v > int64(math.MaxInt64)
 	}
+	return false
 }
 
-func isOverflowsIntByUint64(v uint64) bool {
-	if strconv.IntSize == 32 {
+func isOverflowsIntByUint64(v uint64, intSize int) bool {
+	if intSize == 32 {
 		return v > uint64(math.MaxInt32)
 	} else {
 		return v > uint64(math.MaxInt64)
@@ -405,13 +408,13 @@ func boundConst(v interface{}, t reflect.Type) interface{} {
 		skind := sval.Kind()
 		if skind == reflect.Uint64 {
 			v := sval.Uint()
-			if isOverflowsIntByUint64(v) {
+			if isOverflowsIntByUint64(v, intSize) {
 				log.Panicf("constant %v overflows int\n", v)
 			}
 			return int(v)
 		} else if skind == reflect.Int64 {
 			v := sval.Int()
-			if isOverflowsIntByInt64(v) {
+			if isOverflowsIntByInt64(v, intSize) {
 				log.Panicf("constant %v overflows int\n", v)
 			}
 			return int(v)

--- a/cl/value.go
+++ b/cl/value.go
@@ -17,7 +17,9 @@
 package cl
 
 import (
+	"math"
 	"reflect"
+	"strconv"
 
 	"github.com/goplus/gop/ast/astutil"
 	"github.com/goplus/gop/exec.spec"
@@ -370,6 +372,22 @@ func kindOf(t reflect.Type) exec.Kind {
 	return kind
 }
 
+func isOverflowsIntByInt64(v int64) bool {
+	if strconv.IntSize == 32 {
+		return v < int64(math.MinInt32) || v > int64(math.MaxInt32)
+	} else {
+		return v < int64(math.MinInt64) || v > int64(math.MaxInt64)
+	}
+}
+
+func isOverflowsIntByUint64(v uint64) bool {
+	if strconv.IntSize == 32 {
+		return v > uint64(math.MaxInt32)
+	} else {
+		return v > uint64(math.MaxInt64)
+	}
+}
+
 func boundConst(v interface{}, t reflect.Type) interface{} {
 	kind := kindOf(t)
 	if v == nil {
@@ -383,7 +401,22 @@ func boundConst(v interface{}, t reflect.Type) interface{} {
 	if t == st {
 		return v
 	}
-	if kind == reflect.Complex128 || kind == reflect.Complex64 {
+	if kind == reflect.Interface {
+		skind := sval.Kind()
+		if skind == reflect.Uint64 {
+			v := sval.Uint()
+			if isOverflowsIntByUint64(v) {
+				log.Panicf("constant %v overflows int\n", v)
+			}
+			return int(v)
+		} else if skind == reflect.Int64 {
+			v := sval.Int()
+			if isOverflowsIntByInt64(v) {
+				log.Panicf("constant %v overflows int\n", v)
+			}
+			return int(v)
+		}
+	} else if kind == reflect.Complex128 || kind == reflect.Complex64 {
 		if skind := sval.Kind(); skind >= reflect.Int && skind <= reflect.Float64 {
 			fval := sval.Convert(exec.TyFloat64).Float()
 			return complex(fval, 0)

--- a/cl/value_test.go
+++ b/cl/value_test.go
@@ -48,4 +48,22 @@ func TestValue(t *testing.T) {
 	_ = c.Value(0)
 }
 
+func TestOverflowsIntBy(t *testing.T) {
+	if isOverflowsIntByInt64(1<<63-1, 64) {
+		t.Fatal("not overflows", 1<<63-1)
+	}
+	if !isOverflowsIntByInt64(1<<31, 32) {
+		t.Fatal("overflows", 1<<31)
+	}
+	if isOverflowsIntByUint64(1<<63-1, 64) {
+		t.Fatal("not overflows", uint64(1<<63-1))
+	}
+	if !isOverflowsIntByUint64(1<<64-1, 64) {
+		t.Fatal("not overflows", uint64(1<<64-1))
+	}
+	if !isOverflowsIntByUint64(1<<32, 32) {
+		t.Fatal("overflows", 1<<32)
+	}
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
const int 类型在转换为 interface{} 调用时确定为 int 类型。
Go+ source
```
v := reflect.ValueOf(100)
println(v.Kind())
--------------- output
int
```
generate Golang code
```
package main

import (
	fmt "fmt"
	reflect "reflect"
)

var v reflect.Value

func main() { 
//line ./main.gop:10
	v = reflect.ValueOf(100)
//line ./main.gop:11
	fmt.Println((reflect.Value).Kind(v))
}
```

已知问题：因为目前 const int 使用的是 int64/uint64 存储，所以在 interface{} 调用转换为 int 时检查 overflows 仅在 32 位环境（gophers)下有效，在 64 位下无效。

