### PR TITLE
repl: dump context return values

### DIFF
--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -467,6 +467,14 @@ func compileReturnStmt(ctx *blockCtx, expr *ast.ReturnStmt) {
 
 func compileExprStmt(ctx *blockCtx, expr *ast.ExprStmt) {
 	compileExpr(ctx, expr.X)()
+	if ctx.infer.Len() > 0 {
+		in := ctx.infer.Get(-1)
+		if v, ok := in.(*constVal); ok {
+			for i := 0; i < v.NumValues(); i++ {
+				checkType(exec.TyEmptyInterface, v.Value(i), ctx.out)
+			}
+		}
+	}
 	ctx.infer.PopN(1)
 }
 

--- a/cmd/internal/repl/replcmd.go
+++ b/cmd/internal/repl/replcmd.go
@@ -82,6 +82,9 @@ func runCmd(cmd *base.Command, args []string) {
 			fmt.Printf("Problem reading line: %v\n", err)
 			continue
 		}
+		if line != "" {
+			state.AppendHistory(line)
+		}
 		repl.Run(line)
 	}
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -133,6 +133,10 @@ func (r *REPL) run(newLine string) (err error) {
 	// "currentip - 1" is the index of `return`
 	// next time it will replace by new code from newLine
 	r.ip = currentIP - 1
+	size := ctx.Len()
+	for i := 0; i < size; i++ {
+		r.term.Printf("%v\n", ctx.Get(i-size))
+	}
 	return
 }
 


### PR DESCRIPTION
```
$./igop
>>> 1+2
3
>>> a := 10
>>> a
10
>>> a+1
11
>>> fn := func(a int, b int) (int,int) { return a+b,a*b}
>>> fn
0x10d6890
>>> fn(10,20)
30
200
>>> c,d := fn(10,20)
>>> c
30
>>> d
200
>>> 
```