### PR TITLE
cl: support var define

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -304,6 +304,23 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 }
 
 func loadConsts(ctx *blockCtx, d *ast.GenDecl) {
+	for _, item := range d.Specs {
+		loadConstSpec(ctx, item.(*ast.ValueSpec))
+	}
+}
+
+func loadConstSpec(ctx *blockCtx, spec *ast.ValueSpec) {
+	for i := 0; i < len(spec.Names); i++ {
+		name := spec.Names[i].Name
+		if len(spec.Values) > i {
+			loadConst(ctx, name, spec.Type, spec.Values[i])
+		} else {
+			loadConst(ctx, name, spec.Type, nil)
+		}
+	}
+}
+
+func loadConst(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {
 }
 
 func loadVars(ctx *blockCtx, d *ast.GenDecl) {

--- a/cl/context.go
+++ b/cl/context.go
@@ -381,13 +381,6 @@ func (p *blockCtx) insertFuncVars(in []reflect.Type, args []string, rets []exec.
 	}
 }
 
-func (p *blockCtx) insertConst(name string, c *constVal) {
-	if p.exists(name) {
-		log.Panicln("insertConst failed: symbol exists -", name)
-	}
-	p.syms[name] = c
-}
-
 func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *execVar {
 	if p.exists(name) {
 		log.Panicln("insertVar failed: symbol exists -", name)

--- a/cl/context.go
+++ b/cl/context.go
@@ -381,6 +381,13 @@ func (p *blockCtx) insertFuncVars(in []reflect.Type, args []string, rets []exec.
 	}
 }
 
+func (p *blockCtx) insertConst(name string, c *constVal) {
+	if p.exists(name) {
+		log.Panicln("insertConst failed: symbol exists -", name)
+	}
+	p.syms[name] = c
+}
+
 func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *execVar {
 	if p.exists(name) {
 		log.Panicln("insertVar failed: symbol exists -", name)

--- a/cl/ctx_check.go
+++ b/cl/ctx_check.go
@@ -82,6 +82,8 @@ func isNoExecCtxStmt(ctx *blockCtx, stmt ast.Stmt) bool {
 		return isNoExecCtxCallExpr(ctx, v.Call)
 	case *ast.GoStmt:
 		return isNoExecCtxCallExpr(ctx, v.Call)
+	case *ast.DeclStmt:
+		return true
 	default:
 		log.Panicln("isNoExecCtxStmt failed: unknown -", reflect.TypeOf(v))
 	}

--- a/cl/ctx_check.go
+++ b/cl/ctx_check.go
@@ -363,6 +363,11 @@ func isNoExecCtxDeclStmt(ctx *blockCtx, expr *ast.DeclStmt) bool {
 						return false
 					}
 				}
+				for i := len(vs.Names) - 1; i >= 0; i-- {
+					if noExecCtx := isNoExecCtxExprLHS(ctx, vs.Names[i], lhsAssign); !noExecCtx {
+						return false
+					}
+				}
 			}
 		}
 	}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -555,6 +555,50 @@ func TestArray(t *testing.T) {
 		"x[1:]: [2.3 3.1 4]\n4\n")
 }
 
+func TestLoadVar(t *testing.T) {
+	cltest.Expect(t, `
+		var x1 int
+		var x2 int = 10
+		var x3 = 10
+		println("x:",x1,x2,x3)
+		`,
+		"x: 0 10 10\n")
+	cltest.Expect(t, `
+		type Point struct {
+			X int
+			Y int
+		}
+		var x1 Point
+		var x2 Point = Point{10,20}
+		var x3 = Point{-10,-20}
+		println("x:",x1,x2,x3)
+		`,
+		"x: {0 0} {10 20} {-10 -20}\n")
+}
+
+func TestLoadVar2(t *testing.T) {
+	cltest.Expect(t, `
+		func main() {
+			var x1 int
+			var x2 int = 10
+			var x3 = 10
+			println("x:",x1,x2,x3)
+		}`,
+		"x: 0 10 10\n")
+	cltest.Expect(t, `
+		type Point struct {
+			X int
+			Y int
+		}
+		func main() {
+			var x1 Point
+			var x2 Point = Point{10,20}
+			var x3 = Point{-10,-20}
+			println("x:",x1,x2,x3)
+		}`,
+		"x: {0 0} {10 20} {-10 -20}\n")
+}
+
 func TestMap(t *testing.T) {
 	cltest.Expect(t, `
 		x := map[string]float64{"Hello": 1, "xsw": 3.4}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -599,6 +599,21 @@ func TestLoadVar2(t *testing.T) {
 		"x: {0 0} {10 20} {-10 -20}\n")
 }
 
+func TestLoadVar3(t *testing.T) {
+	cltest.Expect(t, `
+		var x1,x2,x3 = 10,20,x1+x2
+		println("x:",x1,x2,x3)
+		`,
+		"x: 10 20 30\n")
+	cltest.Expect(t, `
+		var x1,x2,x3 = 10,20,x1+x2
+		func main() {
+			println("x:",x1,x2,x3)
+		}
+		`,
+		"x: 10 20 30\n")
+}
+
 func TestMap(t *testing.T) {
 	cltest.Expect(t, `
 		x := map[string]float64{"Hello": 1, "xsw": 3.4}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -597,6 +597,19 @@ func TestLoadVar2(t *testing.T) {
 			println("x:",x1,x2,x3)
 		}`,
 		"x: {0 0} {10 20} {-10 -20}\n")
+
+	cltest.Expect(t, `
+		func main() {
+			type Point struct {
+				X int
+				Y int
+			}
+			var x1 Point
+			var x2 Point = Point{10,20}
+			var x3 = Point{-10,-20}
+			println("x:",x1,x2,x3)
+		}`,
+		"x: {0 0} {10 20} {-10 -20}\n")
 }
 
 func TestLoadVar3(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -794,6 +794,19 @@ func TestRational(t *testing.T) {
 	`).Equal(big.NewRat(7, 3))
 }
 
+func TestIsNoExecCtx(t *testing.T) {
+	cltest.Expect(t, `
+	fns := make([]func() int, 3)
+	for i, x <- [3, 15, 777] {
+		var v = x
+		var fn = func() int {
+			return v
+		}
+		fns[i] = fn
+	}
+	println("values:", fns[0](), fns[1](), fns[2]())`, "values: 3 15 777\n")
+}
+
 type testData struct {
 	clause string
 	want   string

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -486,7 +486,7 @@ func compileDeclStmt(ctx *blockCtx, expr *ast.DeclStmt) {
 		case token.CONST:
 			loadConsts(ctx, d)
 		case token.VAR:
-			loadVars(ctx, d)
+			loadVars(ctx, d, expr)
 		default:
 			log.Panicln("tok:", d.Tok, "spec:", reflect.TypeOf(d.Specs).Elem())
 		}

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -81,6 +81,8 @@ func compileStmt(ctx *blockCtx, stmt ast.Stmt) {
 		compileDeferStmt(ctx, v)
 	case *ast.GoStmt:
 		compileGoStmt(ctx, v)
+	case *ast.DeclStmt:
+		compileDeclStmt(ctx, v)
 	case *ast.EmptyStmt:
 		// do nothing
 	default:
@@ -473,6 +475,22 @@ func compileExprStmt(ctx *blockCtx, expr *ast.ExprStmt) {
 		}
 	}
 	ctx.infer.PopN(1)
+}
+
+func compileDeclStmt(ctx *blockCtx, expr *ast.DeclStmt) {
+	switch d := expr.Decl.(type) {
+	case *ast.GenDecl:
+		switch d.Tok {
+		case token.TYPE:
+			loadTypes(ctx, d)
+		case token.CONST:
+			loadConsts(ctx, d)
+		case token.VAR:
+			loadVars(ctx, d)
+		default:
+			log.Panicln("tok:", d.Tok, "spec:", reflect.TypeOf(d.Specs).Elem())
+		}
+	}
 }
 
 func compileIncDecStmt(ctx *blockCtx, expr *ast.IncDecStmt) {

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -158,10 +158,18 @@ func (p *Builder) Resolve() *Code {
 		decls = append(decls, gblvars)
 	}
 	p.endBlockStmt(0)
+
 	if len(p.gblScope.stmts) != 0 {
+		fnName := "main"
+		for _, decl := range p.gblDecls {
+			if d, ok := decl.(*ast.FuncDecl); ok && d.Name.Name == "main" {
+				fnName = "init"
+				break
+			}
+		}
 		body := &ast.BlockStmt{List: p.gblScope.stmts}
 		fn := &ast.FuncDecl{
-			Name: Ident("main"),
+			Name: Ident(fnName),
 			Type: FuncType(p, tyMainFunc),
 			Body: body,
 		}

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -223,29 +223,12 @@ func (p *Builder) resolveTypes() *ast.GenDecl {
 		if typ.Kind() == reflect.Ptr {
 			typ = typ.Elem()
 		}
-		if typ.Kind() == reflect.Struct {
-			fieldList := &ast.FieldList{}
-			for i := 0; i < typ.NumField(); i++ {
-				field := typ.Field(i)
-				fieldList.List = append(fieldList.List, &ast.Field{
-					Names: []*ast.Ident{Ident(field.Name)},
-					Type:  Type(p, field.Type),
-				})
-			}
 
-			StructType := &ast.StructType{Fields: fieldList}
-			spec := &ast.TypeSpec{
-				Name: Ident(t.Name()),
-				Type: StructType,
-			}
-			specs = append(specs, spec)
-		} else {
-			spec := &ast.TypeSpec{
-				Name: Ident(t.Name()),
-				Type: Type(p, t.Type()),
-			}
-			specs = append(specs, spec)
+		spec := &ast.TypeSpec{
+			Name: Ident(t.Name()),
+			Type: Type(p, typ, true),
 		}
+		specs = append(specs, spec)
 	}
 	if len(specs) > 0 {
 		return &ast.GenDecl{

--- a/exec/golang/testdata/29.var-def/var_def.gop
+++ b/exec/golang/testdata/29.var-def/var_def.gop
@@ -1,0 +1,16 @@
+type Point struct {
+	X int
+	Y int
+}
+
+var (
+	i, j, k int = 100, 200, i + j
+)
+
+func main() {
+	var x = Point{10, 20}
+	var pt Point
+	pt.X = 10
+	pt.Y = -10
+	println(i, j, k, x, pt)
+}

--- a/exec/golang/testdata/29.var-def/var_def.gop
+++ b/exec/golang/testdata/29.var-def/var_def.gop
@@ -3,14 +3,17 @@ type Point struct {
 	Y int
 }
 
+type Int int
+
 var (
 	i, j, k int = 100, 200, i + j
 )
 
 func main() {
 	var x = Point{10, 20}
+	var m Int = 10
 	var pt Point
 	pt.X = 10
 	pt.Y = -10
-	println(i, j, k, x, pt)
+	println(i, j, k, m, x, pt)
 }

--- a/exec/golang/testdata/29.var-def/var_def.gop
+++ b/exec/golang/testdata/29.var-def/var_def.gop
@@ -3,17 +3,14 @@ type Point struct {
 	Y int
 }
 
-type Int int
-
 var (
 	i, j, k int = 100, 200, i + j
 )
 
 func main() {
 	var x = Point{10, 20}
-	var m Int = 10
 	var pt Point
 	pt.X = 10
 	pt.Y = -10
-	println(i, j, k, m, x, pt)
+	println(i, j, k, x, pt)
 }


### PR DESCRIPTION
cl: support var define

Go+ code
```
import "image"

type Point struct {
	X int
	Y int
}

var (
	i,j,k int = 100,200,i+j
)

func main() {
	var x = Point{10,20}
	var pt image.Point
	pt.X = 10
	pt.Y = -10
	println(i,j,k,x,pt)
}
```
generate Golang code error
```
package main

import (
	fmt "fmt"
	image "image"
)

type Point struct {
	X int
	Y int
}

var (
	i int
	j int
	k int
)

func init() { 
//line ./main.gop:9
	i = 100
//line ./main.gop:9
	j = 200
//line ./main.gop:9
	k = i + j
}
func main() {
	var (
		x  Point
		pt image.Point
	)
//line ./main.gop:14
	x = Point{X: 10, Y: 20}
//line ./main.gop:16
	pt.X = 10
//line ./main.gop:17
	pt.Y = -10
//line ./main.gop:18
	fmt.Println(i, j, k, x, pt)
}
```