### PR TITLE
support user-defined type convert

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -187,6 +187,11 @@ func compileIdent(ctx *blockCtx, name string) func() {
 			return func() { // TODO: maybe slowly, use Closure instead of GoClosure
 				ctx.out.GoClosure(fn.fi)
 			}
+		case *typeDecl:
+			ctx.infer.Push(&nonValue{v.Type})
+			return func() {
+				log.Panicln("TODO")
+			}
 		default:
 			log.Panicln("compileIdent failed: unknown -", reflect.TypeOf(sym))
 		}
@@ -1075,21 +1080,23 @@ func compileSelectorExprLHS(ctx *blockCtx, v *ast.SelectorExpr, mode compileMode
 	case *goValue:
 		_, t := countPtr(vx.t)
 		name := v.Sel.Name
-		if sf, ok := t.FieldByName(name); ok {
-			checkType(sf.Type, in, ctx.out)
-			if ctx.fieldIndex == nil {
-				ctx.fieldStructType = vx.t
+		if t.Kind() == reflect.Struct {
+			if sf, ok := t.FieldByName(name); ok {
+				checkType(sf.Type, in, ctx.out)
+				if ctx.fieldIndex == nil {
+					ctx.fieldStructType = vx.t
+				}
+				fieldIndex := append(ctx.fieldIndex, sf.Index...)
+				fieldStructType := ctx.fieldStructType
+				ctx.checkLoadAddr = true
+				if ctx.fieldExprX != nil {
+					ctx.fieldExprX()
+				} else {
+					exprX()
+				}
+				ctx.checkLoadAddr = false
+				ctx.out.StoreField(fieldStructType, fieldIndex)
 			}
-			fieldIndex := append(ctx.fieldIndex, sf.Index...)
-			fieldStructType := ctx.fieldStructType
-			ctx.checkLoadAddr = true
-			if ctx.fieldExprX != nil {
-				ctx.fieldExprX()
-			} else {
-				exprX()
-			}
-			ctx.checkLoadAddr = false
-			ctx.out.StoreField(fieldStructType, fieldIndex)
 		}
 	default:
 		log.Panicln("compileSelectorExprLHS failed: unknown -", reflect.TypeOf(vx))
@@ -1150,24 +1157,26 @@ func compileSelectorExpr(ctx *blockCtx, v *ast.SelectorExpr, allowAutoCall bool)
 		n, t := countPtr(vx.t)
 		autoCall := false
 		name := v.Sel.Name
-		if sf, ok := t.FieldByName(name); ok {
-			ctx.infer.Ret(1, &goValue{t: sf.Type})
-			if ctx.fieldIndex == nil {
-				ctx.fieldExprX = exprX
-				ctx.fieldStructType = vx.t
-			}
-			ctx.fieldIndex = append(ctx.fieldIndex, sf.Index...)
-			fieldIndex := ctx.fieldIndex
-			fieldExprX := ctx.fieldExprX
-			fieldStructType := ctx.fieldStructType
-			return func() {
-				if fieldExprX != nil {
-					fieldExprX()
+		if t.Kind() == reflect.Struct {
+			if sf, ok := t.FieldByName(name); ok {
+				ctx.infer.Ret(1, &goValue{t: sf.Type})
+				if ctx.fieldIndex == nil {
+					ctx.fieldExprX = exprX
+					ctx.fieldStructType = vx.t
 				}
-				if ctx.takeAddr || ctx.checkLoadAddr {
-					ctx.out.AddrField(fieldStructType, fieldIndex)
-				} else {
-					ctx.out.LoadField(fieldStructType, fieldIndex)
+				ctx.fieldIndex = append(ctx.fieldIndex, sf.Index...)
+				fieldIndex := ctx.fieldIndex
+				fieldExprX := ctx.fieldExprX
+				fieldStructType := ctx.fieldStructType
+				return func() {
+					if fieldExprX != nil {
+						fieldExprX()
+					}
+					if ctx.takeAddr || ctx.checkLoadAddr {
+						ctx.out.AddrField(fieldStructType, fieldIndex)
+					} else {
+						ctx.out.LoadField(fieldStructType, fieldIndex)
+					}
 				}
 			}
 		}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -189,9 +189,7 @@ func compileIdent(ctx *blockCtx, name string) func() {
 			}
 		case *typeDecl:
 			ctx.infer.Push(&nonValue{v.Type})
-			return func() {
-				log.Panicln("TODO")
-			}
+			return nil
 		default:
 			log.Panicln("compileIdent failed: unknown -", reflect.TypeOf(sym))
 		}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1024,6 +1024,18 @@ var testMethodClauses = map[string]testData{
 
 					p.SetName("foo",31)
 					`, "foo\n31\n", false},
+	"method int type": {`
+					
+					type M int
+
+					func (m M) Foo() {
+						println("foo", m)
+					}
+
+					m := M(0)
+					m.Foo()
+					println(m)
+					`, "foo 0\n0\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -211,23 +211,14 @@ func (p *Builder) resolveTypes() *ast.GenDecl {
 	n := len(p.types)
 	specs := make([]ast.Spec, 0, n)
 	for _, t := range p.types {
-		fieldList := &ast.FieldList{}
 		typ := t.Type()
 		if typ.Kind() == reflect.Ptr {
 			typ = typ.Elem()
 		}
-		for i := 0; i < typ.NumField(); i++ {
-			field := typ.Field(i)
-			fieldList.List = append(fieldList.List, &ast.Field{
-				Names: []*ast.Ident{Ident(field.Name)},
-				Type:  Type(p, field.Type),
-			})
-		}
 
-		StructType := &ast.StructType{Fields: fieldList}
 		spec := &ast.TypeSpec{
 			Name: Ident(t.Name()),
-			Type: StructType,
+			Type: Type(p, typ, true),
 		}
 		specs = append(specs, spec)
 	}

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -427,34 +427,35 @@ func main() {
 	}
 }
 
-type Person struct {
-	Name string
-	Age  int
-}
-
 func TestType(t *testing.T) {
 	println, _ := I.FindFuncv("println")
 
 	codeExp := `package main
 
-import (
-	fmt "fmt"
-	golang "github.com/goplus/gop/exec/golang"
-)
+import fmt "fmt"
 
 type Person struct {
 	Name string
 	Age  int
 }
 
-var p golang.Person
+var p Person
 
 func main() {
-	p = golang.Person{Name: "bar", Age: 30}
+	p = Person{Name: "bar", Age: 30}
 	fmt.Println(p)
 }
 `
-	typ := reflect.TypeOf(Person{})
+	typ := reflect.StructOf([]reflect.StructField{
+		{
+			Name: "Name",
+			Type: exec.TyString,
+		},
+		{
+			Name: "Age",
+			Type: exec.TyInt,
+		},
+	})
 
 	p := NewVar(typ, "p")
 

--- a/exec/golang/testdata/28.method/method.gop
+++ b/exec/golang/testdata/28.method/method.gop
@@ -32,7 +32,8 @@ p := &Person{
 
 p.Name, p.Age = "bar2", 31
 
-m := M(0)
+a := int32(0)
+m := M(a)
 
 p.SetName("foo")
 p.SetAge(32)

--- a/exec/golang/testdata/28.method/method.gop
+++ b/exec/golang/testdata/28.method/method.gop
@@ -19,6 +19,12 @@ func (p *Person) AddFriends(args ...string) {
 	p.Friends = append(p.Friends, args...)
 }
 
+type M int
+
+func (m M) Foo() {
+	println("foo", m)
+}
+
 p := &Person{
 	Name: "bar",
 	Age:  30,
@@ -26,10 +32,14 @@ p := &Person{
 
 p.Name, p.Age = "bar2", 31
 
+m := M(0)
+
 p.SetName("foo")
 p.SetAge(32)
 p.AddFriends("a", "b", "c")
+m.Foo()
 
 println(p.Name)
 println(p.Age)
 println(p.Friends)
+println(m)

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -28,9 +28,6 @@ import (
 
 // StructType instr
 func StructType(p *Builder, typ reflect.Type) ast.Expr {
-	if gtype, ok := p.types[typ]; ok {
-		return Ident(gtype.Name())
-	}
 	var fields = &ast.FieldList{}
 	for i := 0; i < typ.NumField(); i++ {
 		fields.List = append(fields.List, toStructField(p, typ.Field(i)))
@@ -137,7 +134,12 @@ func FuncType(p *Builder, typ reflect.Type) *ast.FuncType {
 }
 
 // Type instr
-func Type(p *Builder, typ reflect.Type) ast.Expr {
+func Type(p *Builder, typ reflect.Type, actualTypes ...bool) ast.Expr {
+	if len(actualTypes) == 0 || (len(actualTypes) > 0 && !actualTypes[0]) {
+		if gtype, ok := p.types[typ]; ok {
+			return Ident(gtype.Name())
+		}
+	}
 	pkgPath, name := typ.PkgPath(), typ.Name()
 	log.Debug(typ, "-", "pkgPath:", pkgPath, "name:", name)
 	if name != "" {

--- a/tutorial/26-Method/method.gop
+++ b/tutorial/26-Method/method.gop
@@ -19,6 +19,12 @@ func (p *Person) AddFriends(args ...string) {
 	p.Friends = append(p.Friends, args...)
 }
 
+type M int
+
+func (m M) Foo() {
+	println("foo", m)
+}
+
 p := Person{
 	Name: "bar",
 	Age:  30,
@@ -30,6 +36,10 @@ p.SetName("foo")
 p.SetAge(32)
 p.AddFriends("a", "b", "c")
 
+m := M(0)
+m.Foo()
+
 println(p.Name)
 println(p.Age)
 println(p.Friends)
+println(m)

--- a/tutorial/26-Method/method.gop
+++ b/tutorial/26-Method/method.gop
@@ -36,7 +36,8 @@ p.SetName("foo")
 p.SetAge(32)
 p.AddFriends("a", "b", "c")
 
-m := M(0)
+a := int32(0)
+m := M(a)
 m.Foo()
 
 println(p.Name)


### PR DESCRIPTION
support user-defined type convert

```
type M int

func (m M) Foo() {
	println("foo", m)
}

m := M(0)
m.Foo()
println(m)
```

now:

```
[PANIC] github.com/goplus/gop/cl/expr.go:191: compileIdent failed: unknown - *cl.typeDecl
panic: compileIdent failed: unknown - *cl.typeDecl
```

fixed:

```
foo 0
0
```

