### PR TITLE
cl: fix user-defined type incorrect lookup

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -108,7 +108,8 @@ type iVar interface {
 }
 
 type execVar struct {
-	v exec.Var
+	v        exec.Var
+	typeDecl *typeDecl
 }
 
 func (p *execVar) inCurrentCtx(ctx *blockCtx) bool {
@@ -298,6 +299,7 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 
 	tDecl := &typeDecl{
 		Type: t,
+		Name: spec.Name.Name,
 	}
 	ctx.syms[spec.Name.Name] = tDecl
 	ctx.types[t] = tDecl

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -96,7 +96,7 @@ func TestBasic(t *testing.T) {
 	_, _ = NewPackage(nil, nil, nil, 0)
 	e := newError(nil, "cannot slice a (type *%v)", "[]int")
 	_ = e.Error()
-	ev := &execVar{exec.NewVar(reflect.TypeOf(0), "")}
+	ev := &execVar{v: exec.NewVar(reflect.TypeOf(0), "")}
 	_ = ev.getType()
 	_ = ev.inCurrentCtx(bctx)
 	sv := new(stackVar)

--- a/cl/context.go
+++ b/cl/context.go
@@ -436,7 +436,11 @@ func (p *blockCtx) insertMethod(recv astutil.RecvInfo, methodName string, decl *
 
 // -----------------------------------------------------------------------------
 
-func (c *blockCtx) findMethod(typ reflect.Type, methodName string) (*funcDecl, bool) {
+func (c *blockCtx) findMethod(typ reflect.Type, typeDecl *typeDecl, methodName string) (*funcDecl, bool) {
+	if typeDecl != nil {
+		fDecl, ok := typeDecl.Methods[methodName]
+		return fDecl, ok
+	}
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 	}

--- a/cl/context.go
+++ b/cl/context.go
@@ -377,7 +377,7 @@ func (p *blockCtx) insertFuncVars(in []reflect.Type, args []string, rets []exec.
 		if ret.IsUnnamedOut() {
 			continue
 		}
-		p.syms[ret.Name()] = &execVar{ret}
+		p.syms[ret.Name()] = &execVar{v: ret}
 	}
 }
 
@@ -389,7 +389,7 @@ func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *
 	if inferOnly == nil {
 		p.out.DefineVar(v)
 	}
-	ev := &execVar{v}
+	ev := &execVar{v: v}
 	p.syms[name] = ev
 	return ev
 }

--- a/cl/context.go
+++ b/cl/context.go
@@ -382,6 +382,10 @@ func (p *blockCtx) insertFuncVars(in []reflect.Type, args []string, rets []exec.
 }
 
 func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *execVar {
+	return p.insertVarEx(name, typ, nil, inferOnly...)
+}
+
+func (p *blockCtx) insertVarEx(name string, typ reflect.Type, typeDecl *typeDecl, inferOnly ...bool) *execVar {
 	if p.exists(name) {
 		log.Panicln("insertVar failed: symbol exists -", name)
 	}
@@ -389,7 +393,7 @@ func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *
 	if inferOnly == nil {
 		p.out.DefineVar(v)
 	}
-	ev := &execVar{v: v}
+	ev := &execVar{v: v, typeDecl: typeDecl}
 	p.syms[name] = ev
 	return ev
 }

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -786,9 +786,9 @@ func compileCallExprCall(ctx *blockCtx, exprFun func(), v *ast.CallExpr, ct call
 			if ct != callExpr {
 				log.Panicf("%s requires function call, not conversion\n", gCallTypes[ct])
 			}
-			return compileTypeCast(nv, ctx, v)
+			return compileTypeCast(nv, nil, ctx, v)
 		case *typeDecl:
-			return compileTypeDeclCast(nv, ctx, v)
+			return compileTypeCast(nv.Type, nv, ctx, v)
 		}
 	}
 	log.Panicln("compileCallExpr failed: unknown -", reflect.TypeOf(fn))

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1183,17 +1183,8 @@ func compileSelectorExpr(ctx *blockCtx, v *ast.SelectorExpr, allowAutoCall bool)
 				}
 			}
 		}
-		if vx.typeDecl != nil {
-			if fDecl, ok := vx.typeDecl.Methods[name]; ok {
-				ctx.infer.Pop()
-				fn := newQlFunc(fDecl)
-				ctx.use(fDecl)
-				ctx.infer.Push(fn)
-				return func() {}
-			}
-		}
 
-		if fDecl, ok := ctx.findMethod(t, name); ok {
+		if fDecl, ok := ctx.findMethod(t, vx.typeDecl, name); ok {
 			ctx.infer.Pop()
 			fn := newQlFunc(fDecl)
 			ctx.use(fDecl)

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -114,9 +114,10 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 		log.Panicln("compileIdentLHS failed:", err, "-", name)
 	} else {
 		typ := boundType(in.(iValue))
-		addr = ctx.insertVar(name, typ)
 		if v, ok := in.(*goValue); ok {
-			addr.(*execVar).typeDecl = v.typeDecl
+			addr = ctx.insertVarEx(name, typ, v.typeDecl)
+		} else {
+			addr = ctx.insertVar(name, typ)
 		}
 	}
 	checkType(addr.getType(), in, ctx.out)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1056,13 +1056,18 @@ var testMethodClauses = map[string]testData{
 					`, "foo 0\nfoo2 1\n0\n1\n", false},
 	"method int type conv": {`
 					type M int
+					type M2 int
 
 					func (m M) Foo() {
 						println("foo", m)
 					}
 
+					func (m M2) Foo() {
+						println("foo2", m)
+					}
 					M(10).Foo()
-					`, "foo 10\n", false},
+					M2(11).Foo()
+					`, "foo 10\nfoo2 11\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1025,7 +1025,6 @@ var testMethodClauses = map[string]testData{
 					p.SetName("foo",31)
 					`, "foo\n31\n", false},
 	"method int type": {`
-					
 					type M int
 
 					func (m M) Foo() {
@@ -1036,6 +1035,34 @@ var testMethodClauses = map[string]testData{
 					m.Foo()
 					println(m)
 					`, "foo 0\n0\n", false},
+	"method two int type": {`
+					type M int
+					type M2 int
+
+					func (m M) Foo() {
+						println("foo", m)
+					}
+
+					func (m M2) Foo() {
+						println("foo2", m)
+					}
+
+					m := M(0)
+					m.Foo()
+					m2 := M2(1)
+					m2.Foo()
+					println(m)
+					println(m2)
+					`, "foo 0\nfoo2 1\n0\n1\n", false},
+	"method int type conv": {`
+					type M int
+
+					func (m M) Foo() {
+						println("foo", m)
+					}
+
+					M(10).Foo()
+					`, "foo 10\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/cl/value.go
+++ b/cl/value.go
@@ -48,7 +48,8 @@ func isBool(v iValue) bool {
 // -----------------------------------------------------------------------------
 
 type goValue struct {
-	t reflect.Type
+	t        reflect.Type
+	typeDecl *typeDecl
 }
 
 func (p *goValue) Kind() iKind {

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -93,13 +93,14 @@ type Builder struct {
 	out         *Code                    // golang code
 	pkgName     string                   // package name
 	types       map[reflect.Type]*GoType // type => gotype
-	imports     map[string]string        // pkgPath => aliasName
-	importPaths map[string]string        // aliasName => pkgPath
-	gblScope    scopeCtx                 // global scope
-	gblDecls    []ast.Decl               // global declarations
-	fset        *token.FileSet           // fileset of Go+ code
-	cfun        *FuncInfo                // current function
-	cstmt       interface{}              // current statement
+	typeList    []*GoType
+	imports     map[string]string // pkgPath => aliasName
+	importPaths map[string]string // aliasName => pkgPath
+	gblScope    scopeCtx          // global scope
+	gblDecls    []ast.Decl        // global declarations
+	fset        *token.FileSet    // fileset of Go+ code
+	cfun        *FuncInfo         // current function
+	cstmt       interface{}       // current statement
 	reserveds   []*printer.ReservedExpr
 	comprehens  func()   // current comprehension
 	identBase   int      // auo-increasement ident index

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -182,6 +182,7 @@ func (p *Builder) DefineType(typ reflect.Type, name string) *Builder {
 		name: name,
 		typ:  typ,
 	}
+	p.typeList = append(p.typeList, &GoType{name: name, typ: typ})
 	return p
 }
 


### PR DESCRIPTION
cl: fix user-defined type incorrect lookup. 
_fixed for exec/bytecode, exec/golang not fixed_

**not ready.** func call , golang etc...

Go+ code
```
type M int
type M2 int
func (m M) Foo() {
	println("foo", m)
}
func (m M2) Foo() {
	println("foo2", m)
}
m := M(10)
m2 := M2(11)
m.Foo()
m2.Foo()
// M(10).Foo() panic
```
Incorrect output 
```
foo2 10
foo2 10
```
Fixed by this PR 
```
foo 10
foo2 11
```
and support
```
M(10).Foo()
M2(11).Foo()
```