### PR TITLE
reflectx: user-defined type/struct wrapper reflect.Type 

### DIFF
--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -20,10 +20,9 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/goplus/gop/reflectx"
-
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/goplus/gop/token"
 	"github.com/qiniu/x/log"
 )

--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"reflect"
 
+	"github.com/goplus/gop/reflectx"
+
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/exec.spec"
 	"github.com/goplus/gop/token"
@@ -146,6 +148,8 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 			panicExprNotValue(n)
 		}
 		typVal := iv.Type()
+		t = reflectx.ToType(t)
+		typVal = reflectx.ToType(typVal)
 		if kind := t.Kind(); kind == reflect.Interface {
 			if !typVal.Implements(t) {
 				log.Panicf("checkType: type `%v` doesn't implments interface `%v`", typVal, t)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -296,7 +296,7 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 	}
 	t := toType(ctx, spec.Type).(reflect.Type)
 
-	t = reflectx.NewUserType(t, spec.Name.Name)
+	t = reflectx.NewUserType(t)
 	ctx.out.DefineType(t, spec.Name.Name)
 
 	tDecl := &typeDecl{

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -25,11 +25,10 @@ import (
 	"reflect"
 	"syscall"
 
-	"github.com/goplus/gop/reflectx"
-
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/ast/astutil"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/goplus/gop/token"
 	"github.com/qiniu/x/log"
 )

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -25,6 +25,8 @@ import (
 	"reflect"
 	"syscall"
 
+	"github.com/goplus/gop/reflectx"
+
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/ast/astutil"
 	"github.com/goplus/gop/exec.spec"
@@ -296,11 +298,13 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 
 	ctx.out.DefineType(t, spec.Name.Name)
 
+	ut := &reflectx.UserType{t, spec.Name.Name}
+
 	tDecl := &typeDecl{
-		Type: t,
+		Type: ut,
 	}
 	ctx.syms[spec.Name.Name] = tDecl
-	ctx.types[t] = tDecl
+	ctx.types[ut] = tDecl
 }
 
 func loadConsts(ctx *blockCtx, d *ast.GenDecl) {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -293,9 +293,16 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 	if ctx.exists(spec.Name.Name) {
 		log.Panicln("loadType failed: symbol exists -", spec.Name.Name)
 	}
-	t := toType(ctx, spec.Type).(reflect.Type)
+	var t reflect.Type
+	switch st := spec.Type.(type) {
+	case *ast.StructType:
+		fields := toStructFieldList(ctx, st)
+		t = reflectx.StructOf(fields)
+	default:
+		t = toType(ctx, spec.Type).(reflect.Type)
+		t = reflectx.NewUserType(t, spec.Type)
+	}
 
-	t = reflectx.NewUserType(t)
 	ctx.out.DefineType(t, spec.Name.Name)
 
 	tDecl := &typeDecl{

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -296,15 +296,14 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 	}
 	t := toType(ctx, spec.Type).(reflect.Type)
 
+	t = reflectx.NewUserType(t, spec.Name.Name)
 	ctx.out.DefineType(t, spec.Name.Name)
 
-	ut := &reflectx.UserType{t, spec.Name.Name}
-
 	tDecl := &typeDecl{
-		Type: ut,
+		Type: t,
 	}
 	ctx.syms[spec.Name.Name] = tDecl
-	ctx.types[ut] = tDecl
+	ctx.types[t] = tDecl
 }
 
 func loadConsts(ctx *blockCtx, d *ast.GenDecl) {

--- a/cl/context.go
+++ b/cl/context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/ast/astutil"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/goplus/gop/token"
 	"github.com/qiniu/x/log"
 )
@@ -418,7 +419,7 @@ func (p *blockCtx) insertMethod(recv astutil.RecvInfo, methodName string, decl *
 	var t reflect.Type = typ.Type
 	pointer := recv.Pointer
 	for pointer > 0 {
-		t = reflect.PtrTo(t)
+		t = reflectx.PtrTo(t)
 		pointer--
 	}
 

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -328,7 +328,7 @@ func compileCompositeLit(ctx *blockCtx, v *ast.CompositeLit) func() {
 			}
 			ctx.takeAddr = old
 			if ctx.takeAddr {
-				ctx.out.Struct(reflect.PtrTo(typStruct), len(v.Elts))
+				ctx.out.Struct(reflectx.PtrTo(typStruct), len(v.Elts))
 			} else {
 				ctx.out.Struct(typStruct, len(v.Elts))
 			}
@@ -548,7 +548,7 @@ func compileUnaryExpr(ctx *blockCtx, v *ast.UnaryExpr) func() {
 		}
 		if v.Op == token.AND {
 			vx := x.(iValue)
-			t := reflect.TypeOf(reflect.New(vx.Type()).Interface())
+			t := reflectx.PtrTo(vx.Type())
 			ret := &goValue{t: t}
 			ctx.infer.Ret(1, ret)
 			return func() {
@@ -1179,7 +1179,6 @@ func compileSelectorExpr(ctx *blockCtx, v *ast.SelectorExpr, allowAutoCall bool)
 				}
 			}
 		}
-
 		if fDecl, ok := ctx.findMethod(t, name); ok {
 			ctx.infer.Pop()
 			fn := newQlFunc(fDecl)

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -23,6 +23,7 @@ import (
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/ast/astutil"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/goplus/gop/token"
 	"github.com/qiniu/x/ctype"
 	"github.com/qiniu/x/errors"
@@ -716,7 +717,7 @@ func compileCallExprCall(ctx *blockCtx, exprFun func(), v *ast.CallExpr, ct call
 					exprX()
 					ctx.checkLoadAddr = false
 					if recv.Kind() != reflect.Ptr {
-						recv.t = reflect.PtrTo(recv.t)
+						recv.t = reflectx.PtrTo(recv.t)
 						ctx.infer.Ret(1, recv)
 					}
 				}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1039,15 +1039,12 @@ var testMethodClauses = map[string]testData{
 	"method two int type": {`
  					type M int
  					type M2 int
-
  					func (m M) Foo() {
  						println("foo", m)
  					}
-
  					func (m M2) Foo() {
  						println("foo2", m)
  					}
-
  					m := M(0)
  					m.Foo()
  					m2 := M2(1)
@@ -1062,10 +1059,10 @@ var testMethodClauses = map[string]testData{
  					func (m M) Foo() {
  						println("foo", m)
  					}
-
  					func (m M2) Foo() {
  						println("foo2", m)
  					}
+
  					M(10).Foo()
  					M2(11).Foo()
  					`, "foo 10\nfoo2 11\n", false},
@@ -1074,30 +1071,41 @@ var testMethodClauses = map[string]testData{
 						X int
 						Y int
 					}
-					
 					func (p *Pt1) Test() {
 						println("pt1", p)
 					}
-					
 					type Pt2 struct {
 						X int
 						Y int
 					}
-					
 					func (p *Pt2) Test() {
 						println("pt2",p)
 					}
-					
+
 					pt1 := Pt1{1,2}
 					pt2 := Pt2{3,4}
 					pt3 := &Pt1{5,6}
 					pt4 := &Pt2{7,8}
-					
+
 					pt1.Test()
 					pt2.Test()
 					pt3.Test()
 					pt4.Test()
 					`, "pt1 &{1 2}\npt2 &{3 4}\npt1 &{5 6}\npt2 &{7 8}\n", false},
+	"method struct field type": {`
+ 					type M int
+ 					func (m M) Foo() {
+ 						println("foo", m)
+ 					}
+					type Pt struct {
+						X M
+						Y M
+					}
+
+					pt := &Pt{10,20}
+					pt.Y.Foo()
+					M(11).Foo()
+ 					`, "foo 20\nfoo 11\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1036,6 +1036,68 @@ var testMethodClauses = map[string]testData{
 					m.Foo()
 					println(m)
 					`, "foo 0\n0\n", false},
+	"method two int type": {`
+ 					type M int
+ 					type M2 int
+
+ 					func (m M) Foo() {
+ 						println("foo", m)
+ 					}
+
+ 					func (m M2) Foo() {
+ 						println("foo2", m)
+ 					}
+
+ 					m := M(0)
+ 					m.Foo()
+ 					m2 := M2(1)
+ 					m2.Foo()
+ 					println(m)
+ 					println(m2)
+ 					`, "foo 0\nfoo2 1\n0\n1\n", false},
+	"method int type conv": {`
+ 					type M int
+ 					type M2 int
+
+ 					func (m M) Foo() {
+ 						println("foo", m)
+ 					}
+
+ 					func (m M2) Foo() {
+ 						println("foo2", m)
+ 					}
+ 					M(10).Foo()
+ 					M2(11).Foo()
+ 					`, "foo 10\nfoo2 11\n", false},
+	"method two struct type": {`
+					type Pt1 struct {
+						X int
+						Y int
+					}
+					
+					func (p *Pt1) Test() {
+						println("pt1", p)
+					}
+					
+					type Pt2 struct {
+						X int
+						Y int
+					}
+					
+					func (p *Pt2) Test() {
+						println("pt2",p)
+					}
+					
+					pt1 := Pt1{1,2}
+					pt2 := Pt2{3,4}
+					pt3 := &Pt1{5,6}
+					pt4 := &Pt2{7,8}
+					
+					pt1.Test()
+					pt2.Test()
+					pt3.Test()
+					pt4.Test()
+					`, "pt1 &{1 2}\npt2 &{3 4}\npt1 &{5 6}\npt2 &{7 8}\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -20,10 +20,9 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/goplus/gop/reflectx"
-
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 )
 
 // -----------------------------------------------------------------------------

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -338,6 +338,7 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 			panicExprNotValue(n)
 		}
 		tIn := iv.Type()
+		typ = reflectx.ToType(typ)
 		if !tIn.ConvertibleTo(typ) {
 			log.Panicf("compileTypeCast: can't convert type `%v` to `%v`\n", tIn, typ)
 		}

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -322,6 +322,10 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 			cons.kind = typ.Kind()
 			if reflectx.IsUserType(typ) {
 				ctx.infer.Ret(1, &goValue{typ})
+				return func() {
+					pushConstVal(ctx.out, cons)
+					ctx.out.TypeCast(cons.Type(), typ)
+				}
 			}
 			return func() {
 				pushConstVal(ctx.out, cons)

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -20,6 +20,8 @@ import (
 	"log"
 	"reflect"
 
+	"github.com/goplus/gop/reflectx"
+
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/exec.spec"
 )
@@ -319,6 +321,9 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 	if kind <= reflect.Complex128 || kind == reflect.String { // can be constant
 		if cons, ok := in.(*constVal); ok {
 			cons.kind = typ.Kind()
+			if reflectx.IsUserType(typ) {
+				ctx.infer.Ret(1, &goValue{typ})
+			}
 			return func() {
 				pushConstVal(ctx.out, cons)
 			}

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -337,8 +337,7 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 			panicExprNotValue(n)
 		}
 		tIn := iv.Type()
-		typ = reflectx.ToType(typ)
-		if !tIn.ConvertibleTo(typ) {
+		if !tIn.ConvertibleTo(reflectx.ToType(typ)) {
 			log.Panicf("compileTypeCast: can't convert type `%v` to `%v`\n", tIn, typ)
 		}
 		ctx.out.TypeCast(tIn, typ)

--- a/cl/type_decl.go
+++ b/cl/type_decl.go
@@ -222,11 +222,19 @@ func toArgTypes(ctx *blockCtx, recv, fields *ast.FieldList) ([]reflect.Type, []s
 	return types, names, false
 }
 
-func toStructType(ctx *blockCtx, v *ast.StructType) iType {
+func toStructFieldList(ctx *blockCtx, v *ast.StructType) []reflect.StructField {
 	var fields []reflect.StructField
 	for _, field := range v.Fields.List {
 		fields = append(fields, toStructField(ctx, field)...)
 	}
+	for i := 0; i < len(fields); i++ {
+		fields[i].Index = []int{i}
+	}
+	return fields
+}
+
+func toStructType(ctx *blockCtx, v *ast.StructType) iType {
+	fields := toStructFieldList(ctx, v)
 	return reflect.StructOf(fields)
 }
 

--- a/cl/type_decl.go
+++ b/cl/type_decl.go
@@ -79,10 +79,10 @@ func toType(ctx *blockCtx, typ ast.Expr) iType {
 	case *ast.MapType:
 		key := toType(ctx, v.Key)
 		elem := toType(ctx, v.Value)
-		return reflect.MapOf(key.(reflect.Type), elem.(reflect.Type))
+		return reflectx.MapOf(key.(reflect.Type), elem.(reflect.Type))
 	case *ast.ChanType:
 		val := toType(ctx, v.Value)
-		return reflect.ChanOf(toChanDir(v.Dir), val.(reflect.Type))
+		return reflectx.ChanOf(toChanDir(v.Dir), val.(reflect.Type))
 	case *ast.Ellipsis:
 		return nil
 	}
@@ -279,7 +279,7 @@ func toIdentType(ctx *blockCtx, ident string) iType {
 func toArrayType(ctx *blockCtx, v *ast.ArrayType) iType {
 	elem := toType(ctx, v.Elt)
 	if v.Len == nil {
-		return reflect.SliceOf(elem.(reflect.Type))
+		return reflectx.SliceOf(elem.(reflect.Type))
 	}
 	compileExpr(ctx, v.Len)
 	n := ctx.infer.Pop()
@@ -288,7 +288,7 @@ func toArrayType(ctx *blockCtx, v *ast.ArrayType) iType {
 			if iv < 0 {
 				return &unboundArrayType{elem: elem.(reflect.Type)}
 			}
-			return reflect.ArrayOf(int(iv), elem.(reflect.Type))
+			return reflectx.ArrayOf(int(iv), elem.(reflect.Type))
 		}
 	}
 	log.Panicln("toArrayType failed: unknown -", reflect.TypeOf(n))

--- a/cl/type_decl.go
+++ b/cl/type_decl.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/qiniu/x/log"
 )
 
@@ -66,7 +67,7 @@ func toType(ctx *blockCtx, typ ast.Expr) iType {
 		return toExternalType(ctx, v)
 	case *ast.StarExpr:
 		elem := toType(ctx, v.X)
-		return reflect.PtrTo(elem.(reflect.Type))
+		return reflectx.PtrTo(elem.(reflect.Type))
 	case *ast.ArrayType:
 		return toArrayType(ctx, v)
 	case *ast.FuncType:

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/qiniu/x/log"
 )
 
@@ -269,7 +270,7 @@ func (p *FuncInfo) Type() reflect.Type {
 		for i := 0; i < p.numOut; i++ {
 			out[i] = p.vlist[i].typ
 		}
-		p.t = reflect.FuncOf(p.in, out, p.IsVariadic())
+		p.t = reflectx.FuncOf(p.in, out, p.IsVariadic())
 	}
 	return p.t
 }

--- a/exec/bytecode/goinstr_lstcompr.go
+++ b/exec/bytecode/goinstr_lstcompr.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/reflectx"
 	"github.com/qiniu/x/log"
 )
 
@@ -159,10 +160,10 @@ func makeArray(typSlice reflect.Type, arity int, p *Context) {
 	var ret, set reflect.Value
 	kind := typSlice.Kind()
 	if kind == reflect.Slice {
-		ret = reflect.MakeSlice(typSlice, arity, arity)
+		ret = reflectx.MakeSlice(typSlice, arity, arity)
 		set = ret
 	} else if kind == reflect.Array {
-		ret = reflect.New(typSlice)
+		ret = reflectx.New(typSlice)
 		set = ret.Elem()
 	} else {
 		log.Panic("makeArray bad type:", typSlice)
@@ -202,20 +203,20 @@ func execMake(i Instr, p *Context) {
 		} else {
 			len = cap
 		}
-		p.Ret(arity, reflect.MakeSlice(typ, len, cap).Interface())
+		p.Ret(arity, reflectx.MakeSlice(typ, len, cap).Interface())
 	case reflect.Map:
 		if arity == 0 {
-			p.Push(reflect.MakeMap(typ).Interface())
+			p.Push(reflectx.MakeMap(typ).Interface())
 			return
 		}
 		n := p.Get(-1).(int)
-		p.Ret(arity, reflect.MakeMapWithSize(typ, n).Interface())
+		p.Ret(arity, reflectx.MakeMapWithSize(typ, n).Interface())
 	case reflect.Chan:
 		var buffer int
 		if arity > 0 {
 			buffer = p.Get(-1).(int)
 		}
-		p.Ret(arity, reflect.MakeChan(typ, buffer).Interface())
+		p.Ret(arity, reflectx.MakeChan(typ, buffer).Interface())
 	default:
 		panic("make: unexpected type")
 	}
@@ -233,7 +234,7 @@ func execMakeMap(i Instr, p *Context) {
 func makeMap(typMap reflect.Type, arity int, p *Context) {
 	n := arity << 1
 	args := p.GetArgs(n)
-	ret := reflect.MakeMapWithSize(typMap, arity)
+	ret := reflectx.MakeMapWithSize(typMap, arity)
 	for i := 0; i < n; i += 2 {
 		key := getKeyOf(args[i], typMap)
 		val := getElementOf(args[i+1], typMap)

--- a/exec/bytecode/struct.go
+++ b/exec/bytecode/struct.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/goplus/gop/reflectx"
 	"github.com/qiniu/x/log"
 )
 
@@ -175,7 +176,7 @@ func makeStruct(typStruct reflect.Type, arity int, p *Context) {
 		ptr = true
 		typStruct = typStruct.Elem()
 	}
-	v := reflect.New(typStruct).Elem()
+	v := reflectx.New(typStruct).Elem()
 	for i := 0; i < n; i += 2 {
 		fieldName := args[i].(string)
 		v.FieldByName(fieldName).Set(reflect.ValueOf(args[i+1]))

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/goplus/gop/exec.spec"
 	"github.com/goplus/gop/exec/golang/internal/go/printer"
+	"github.com/goplus/gop/reflectx"
 	"github.com/qiniu/x/log"
 )
 
@@ -91,7 +92,7 @@ func (p *FuncInfo) Type() reflect.Type {
 			in = append(in, p.recv)
 		}
 		in = append(in, p.in...)
-		p.t = reflect.FuncOf(in, out, p.IsVariadic())
+		p.t = reflectx.FuncOf(in, out, p.IsVariadic())
 	}
 	return p.t
 }

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -253,6 +253,7 @@ func (p *Builder) EndFunc(fun *FuncInfo) *Builder {
 			Type: toFuncType(p, fun),
 			Body: body,
 		}
+
 		if fun.isMethod == 1 {
 			params := make([]*ast.Field, 1)
 			params[0] = Field(p, "recv", fun.recv, "", false)

--- a/exec/golang/testdata/28.method/method.gop
+++ b/exec/golang/testdata/28.method/method.gop
@@ -44,3 +44,20 @@ println(p.Name)
 println(p.Age)
 println(p.Friends)
 println(m)
+
+ar1 := make([]M, 1, 1)
+ar1[0] = 10
+ar1[0].Foo()
+
+ar2 := [2]M{10, 11}
+ar2[0].Foo()
+
+ar3 := []M{12}
+ar3[0].Foo()
+
+m1 := make(map[int]M)
+m1[0] = 13
+m1[0].Foo()
+
+m2 := map[int]M{0: 14}
+m2[0].Foo()

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -51,13 +51,6 @@ func MapType(p *Builder, typ reflect.Type) *ast.MapType {
 	return &ast.MapType{Key: key, Value: val}
 }
 
-// ChanType instr
-func ChanType(p *Builder, typ reflect.Type) *ast.ChanType {
-	dir := typ.ChanDir()
-	val := Type(p, typ.Elem())
-	return &ast.ChanType{Dir: ast.ChanDir(dir), Value: val}
-}
-
 // ArrayType instr
 func ArrayType(p *Builder, typ reflect.Type) *ast.ArrayType {
 	var len ast.Expr
@@ -169,7 +162,6 @@ func Type(p *Builder, typ reflect.Type, actualTypes ...bool) ast.Expr {
 	case reflect.Interface:
 		return InterfaceType(p, typ)
 	case reflect.Chan:
-		return ChanType(p, typ)
 	case reflect.Struct:
 		return StructType(p, typ)
 	}

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -51,6 +51,13 @@ func MapType(p *Builder, typ reflect.Type) *ast.MapType {
 	return &ast.MapType{Key: key, Value: val}
 }
 
+// ChanType instr
+func ChanType(p *Builder, typ reflect.Type) *ast.ChanType {
+	dir := typ.ChanDir()
+	val := Type(p, typ.Elem())
+	return &ast.ChanType{Dir: ast.ChanDir(dir), Value: val}
+}
+
 // ArrayType instr
 func ArrayType(p *Builder, typ reflect.Type) *ast.ArrayType {
 	var len ast.Expr
@@ -162,6 +169,7 @@ func Type(p *Builder, typ reflect.Type, actualTypes ...bool) ast.Expr {
 	case reflect.Interface:
 		return InterfaceType(p, typ)
 	case reflect.Chan:
+		return ChanType(p, typ)
 	case reflect.Struct:
 		return StructType(p, typ)
 	}

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,4 @@ github.com/peterh/liner v1.2.0 h1:w/UPXyl5GfahFxcTOz2j9wCIHNI+pUPr2laqpojKNCg=
 github.com/peterh/liner v1.2.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/qiniu/x v1.11.5 h1:TYr5cl4g2yoHAZeDK4MTjKF6CMoG+IHlCDvvM5qym6U=
 github.com/qiniu/x v1.11.5/go.mod h1:03Ni9tj+N2h2aKnAz+6N0Xfl8FwMEDRC2PAlxekASDs=
+github.com/visualfc/goplus v2.9.60+incompatible h1:Z5ELGRkN7haEn4piD+ENkJApBdw4M4KClEDALxnCIgM=

--- a/reflectx/reflectx.go
+++ b/reflectx/reflectx.go
@@ -6,8 +6,9 @@ import (
 
 type UserType struct {
 	reflect.Type
-	elem  *UserType
-	value interface{}
+	elem  reflect.Type
+	key   reflect.Type
+	field interface{}
 }
 
 func (t *UserType) Elem() reflect.Type {
@@ -17,8 +18,15 @@ func (t *UserType) Elem() reflect.Type {
 	return t.Type.Elem()
 }
 
+func (t *UserType) Key() reflect.Type {
+	if t.key != nil {
+		return t.key
+	}
+	return t.Type.Key()
+}
+
 func (t *UserType) FieldByName(name string) (sf reflect.StructField, ok bool) {
-	if st, ok := t.value.([]reflect.StructField); ok {
+	if st, ok := t.field.([]reflect.StructField); ok {
 		for _, t := range st {
 			if t.Name == name {
 				return t, true
@@ -29,26 +37,14 @@ func (t *UserType) FieldByName(name string) (sf reflect.StructField, ok bool) {
 }
 
 func (t *UserType) Field(i int) reflect.StructField {
-	if st, ok := t.value.([]reflect.StructField); ok {
+	if st, ok := t.field.([]reflect.StructField); ok {
 		return st[i]
 	}
 	return t.Type.Field(i)
 }
 
 func NewUserType(t reflect.Type, value interface{}) reflect.Type {
-	return &UserType{Type: t, value: value}
-}
-
-func StructOf(fields []reflect.StructField) reflect.Type {
-	t := reflect.StructOf(fields)
-	return &UserType{Type: t, value: fields}
-}
-
-func PtrTo(t reflect.Type) reflect.Type {
-	if ut, ok := t.(*UserType); ok {
-		return &UserType{Type: reflect.PtrTo(ut.Type), elem: ut}
-	}
-	return reflect.PtrTo(t)
+	return &UserType{Type: t, field: value}
 }
 
 func IsUserType(t reflect.Type) bool {
@@ -75,8 +71,77 @@ func ToTypes(typs []reflect.Type) []reflect.Type {
 	return ret
 }
 
+func StructOf(fields []reflect.StructField) reflect.Type {
+	t := reflect.StructOf(fields)
+	return &UserType{Type: t, field: fields}
+}
+
+func PtrTo(t reflect.Type) reflect.Type {
+	if ut, ok := t.(*UserType); ok {
+		return &UserType{Type: reflect.PtrTo(ut.Type), elem: ut}
+	}
+	return reflect.PtrTo(t)
+}
+
 func FuncOf(in, out []reflect.Type, variadic bool) reflect.Type {
 	return reflect.FuncOf(ToTypes(in), ToTypes(out), variadic)
+}
+
+func SliceOf(t reflect.Type) reflect.Type {
+	if ut, ok := t.(*UserType); ok {
+		return &UserType{Type: reflect.SliceOf(ut.Type), elem: ut}
+	}
+	return reflect.SliceOf(t)
+}
+
+func ArrayOf(count int, elem reflect.Type) reflect.Type {
+	if ut, ok := elem.(*UserType); ok {
+		return &UserType{Type: reflect.ArrayOf(count, ut.Type), elem: ut}
+	}
+	return reflect.ArrayOf(count, elem)
+}
+
+func ChanOf(dir reflect.ChanDir, typ reflect.Type) reflect.Type {
+	if ut, ok := typ.(*UserType); ok {
+		return &UserType{Type: reflect.ChanOf(dir, ut.Type), elem: ut}
+	}
+	return reflect.ChanOf(dir, typ)
+}
+
+func MapOf(key reflect.Type, value reflect.Type) reflect.Type {
+	var user bool
+	uKey := key
+	uValue := value
+	if ut, ok := key.(*UserType); ok {
+		key = ut.Type
+		uKey = ut
+		user = true
+	}
+	if ut, ok := value.(*UserType); ok {
+		value = ut.Type
+		uValue = ut
+		user = true
+	}
+	if user {
+		return &UserType{Type: reflect.MapOf(key, value), key: uKey, elem: uValue}
+	}
+	return reflect.MapOf(key, value)
+}
+
+func MakeSlice(typ reflect.Type, len, cap int) reflect.Value {
+	return reflect.MakeSlice(ToType(typ), len, cap)
+}
+
+func MakeMap(typ reflect.Type) reflect.Value {
+	return reflect.MakeMap(ToType(typ))
+}
+
+func MakeMapWithSize(typ reflect.Type, n int) reflect.Value {
+	return reflect.MakeMapWithSize(ToType(typ), n)
+}
+
+func MakeChan(typ reflect.Type, buffer int) reflect.Value {
+	return reflect.MakeChan(ToType(typ), buffer)
 }
 
 func New(t reflect.Type) reflect.Value {

--- a/reflectx/reflectx.go
+++ b/reflectx/reflectx.go
@@ -28,6 +28,13 @@ func (t *UserType) FieldByName(name string) (sf reflect.StructField, ok bool) {
 	return t.Type.FieldByName(name)
 }
 
+func (t *UserType) Field(i int) reflect.StructField {
+	if st, ok := t.value.([]reflect.StructField); ok {
+		return st[i]
+	}
+	return t.Type.Field(i)
+}
+
 func NewUserType(t reflect.Type, value interface{}) reflect.Type {
 	return &UserType{Type: t, value: value}
 }

--- a/reflectx/reflectx.go
+++ b/reflectx/reflectx.go
@@ -6,12 +6,35 @@ import (
 
 type UserType struct {
 	reflect.Type
-	User interface{}
+	name string
+	elem *UserType
+}
+
+func (t *UserType) TypeName() string {
+	return t.name
+}
+
+func (t *UserType) Name() string {
+	if t.Type.Kind() == reflect.Ptr {
+		return "*" + t.name
+	}
+	return t.Type.Name()
+}
+
+func (t *UserType) Elem() reflect.Type {
+	if t.elem != nil {
+		return t.elem
+	}
+	return t.Type.Elem()
+}
+
+func NewUserType(t reflect.Type, name string) reflect.Type {
+	return &UserType{Type: t, name: name}
 }
 
 func PtrTo(t reflect.Type) reflect.Type {
 	if ut, ok := t.(*UserType); ok {
-		return &UserType{reflect.PtrTo(ut.Type), ut.User}
+		return &UserType{reflect.PtrTo(ut.Type), ut.name, ut}
 	}
 	return reflect.PtrTo(t)
 }
@@ -28,16 +51,16 @@ func ToType(t reflect.Type) reflect.Type {
 	return t
 }
 
-func ToTypes(in []reflect.Type) []reflect.Type {
-	out := make([]reflect.Type, len(in))
-	for i := 0; i < len(in); i++ {
-		if ut, ok := in[i].(*UserType); ok {
-			out[i] = ut.Type
+func ToTypes(typs []reflect.Type) []reflect.Type {
+	ret := make([]reflect.Type, len(typs))
+	for i := 0; i < len(typs); i++ {
+		if ut, ok := typs[i].(*UserType); ok {
+			ret[i] = ut.Type
 		} else {
-			out[i] = in[i]
+			ret[i] = typs[i]
 		}
 	}
-	return out
+	return ret
 }
 
 func FuncOf(in, out []reflect.Type, variadic bool) reflect.Type {

--- a/reflectx/reflectx.go
+++ b/reflectx/reflectx.go
@@ -6,19 +6,7 @@ import (
 
 type UserType struct {
 	reflect.Type
-	name string
 	elem *UserType
-}
-
-func (t *UserType) TypeName() string {
-	return t.name
-}
-
-func (t *UserType) Name() string {
-	if t.Type.Kind() == reflect.Ptr {
-		return "*" + t.name
-	}
-	return t.Type.Name()
 }
 
 func (t *UserType) Elem() reflect.Type {
@@ -28,13 +16,13 @@ func (t *UserType) Elem() reflect.Type {
 	return t.Type.Elem()
 }
 
-func NewUserType(t reflect.Type, name string) reflect.Type {
-	return &UserType{Type: t, name: name}
+func NewUserType(t reflect.Type) reflect.Type {
+	return &UserType{Type: t}
 }
 
 func PtrTo(t reflect.Type) reflect.Type {
 	if ut, ok := t.(*UserType); ok {
-		return &UserType{reflect.PtrTo(ut.Type), ut.name, ut}
+		return &UserType{reflect.PtrTo(ut.Type), ut}
 	}
 	return reflect.PtrTo(t)
 }

--- a/reflectx/reflectx.go
+++ b/reflectx/reflectx.go
@@ -1,0 +1,49 @@
+package reflectx
+
+import (
+	"reflect"
+)
+
+type UserType struct {
+	reflect.Type
+	User interface{}
+}
+
+func PtrTo(t reflect.Type) reflect.Type {
+	if ut, ok := t.(*UserType); ok {
+		return &UserType{reflect.PtrTo(ut.Type), ut.User}
+	}
+	return reflect.PtrTo(t)
+}
+
+func IsUserType(t reflect.Type) bool {
+	_, ok := t.(*UserType)
+	return ok
+}
+
+func ToType(t reflect.Type) reflect.Type {
+	if ut, ok := t.(*UserType); ok {
+		return ut.Type
+	}
+	return t
+}
+
+func ToTypes(in []reflect.Type) []reflect.Type {
+	out := make([]reflect.Type, len(in))
+	for i := 0; i < len(in); i++ {
+		if ut, ok := in[i].(*UserType); ok {
+			out[i] = ut.Type
+		} else {
+			out[i] = in[i]
+		}
+	}
+	return out
+}
+
+func FuncOf(in, out []reflect.Type, variadic bool) reflect.Type {
+	return reflect.FuncOf(ToTypes(in), ToTypes(out), variadic)
+}
+
+func New(t reflect.Type) reflect.Value {
+	return reflect.New(ToType(t))
+}


### PR DESCRIPTION
Add new reflectx package for wrapper reflect.Type 

try to fix https://github.com/goplus/gop/issues/572

**not ready, must more test.**

Go + code
```
type Pt1 struct {
	X int
	Y int
}
func (p *Pt1) Test() {
	println("pt1", p)
}
type Pt2 struct {
	X int
	Y int
}
func (p *Pt2) Test() {
	println("pt2",p)
}

type M int
type M2 int

type Pt3 struct {
	X M
	Y M2
}
func (m M) Foo() {
	println("foo", m)
}
func (m M2) Foo() {
	println("foo2", m)
}

m := M(10)
m2 := M2(11)

m.Foo()  // foo 10
m2.Foo() // foo2 11

M(12).Foo() // foo 12

pt1 := &Pt1{10,20} 
pt2 := Pt2{1,2}
pt3 := &Pt3{100,200}

pt1.Test()  // pt1 &{10 20}
pt2.Test()  // pt2 &{1 2}
pt3.Y.Foo() // foo2 100
```

generate Golang code
```
package main

import fmt "fmt"

type (
	M2  int
	Pt3 struct {
		X M
		Y M2
	}
	Pt1 struct {
		X int
		Y int
	}
	Pt2 struct {
		X int
		Y int
	}
	M int
)

var (
	m   M
	m2  M2
	pt1 *Pt1
	pt2 Pt2
	pt3 *Pt3
)

func main() { 
//line ./main.gop:33
	m = M(10)
//line ./main.gop:34
	m2 = M2(11)
//line ./main.gop:36
	m.Foo()
//line ./main.gop:37
	m2.Foo()
//line ./main.gop:39
	M(12).Foo()
//line ./main.gop:41
	pt1 = &Pt1{X: 10, Y: 20}
//line ./main.gop:42
	pt2 = Pt2{X: 1, Y: 2}
//line ./main.gop:43
	pt3 = &Pt3{X: 100, Y: 200}
//line ./main.gop:45
	pt1.Test()
//line ./main.gop:46
	pt2.Test()
//line ./main.gop:47
	pt3.Y.Foo()
}
func (recv *Pt2) Test() { 
//line ./main.gop:14
	fmt.Println("pt2", recv)
}
func (recv *Pt1) Test() { 
//line ./main.gop:7
	fmt.Println("pt1", recv)
}
func (recv M2) Foo() { 
//line ./main.gop:30
	fmt.Println("foo2", recv)
}
func (recv M) Foo() { 
//line ./main.gop:26
	fmt.Println("foo", recv)
}
```
