### PR TITLE
cl,golang: fix #581, compileReturnStmt result count check

### DIFF
--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -819,6 +819,36 @@ func TestResult(t *testing.T) {
 	n, err := w.Write("hello")
 	println(n,err)
 	`, "hello\n6 <nil>\n")
+	cltest.Expect(t, `
+	import "fmt"
+	type Writer struct {
+	}
+	func (w *Writer) Write(data string) (int, error) {
+		fmt.Println(data)
+		return len(data)+1,nil
+	}
+	w := &Writer{}
+	n, err := w.Write("hello")
+	println(n,err)
+	`, "hello\n6 <nil>\n")
+	cltest.Expect(t, `
+	import "fmt"
+	type Writer struct {
+	}
+	func myint(n int) int {
+		return n
+	}
+	func myerr(err error) error {
+		return err
+	}
+	func (w *Writer) Write(data string) (int, error) {
+		n, err := fmt.Println(data)
+		return myint(n),myerr(err)
+	}
+	w := &Writer{}
+	n, err := w.Write("hello")
+	println(n,err)
+	`, "hello\n6 <nil>\n")
 }
 
 type testData struct {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -851,6 +851,32 @@ func TestResult(t *testing.T) {
 	`, "hello\n6 <nil>\n")
 }
 
+func TestBadResult(t *testing.T) {
+	cltest.Expect(t, `
+	import "fmt"
+	type Writer struct {
+	}
+	func (w *Writer) Write(data string) (error) {
+		err := fmt.Println(data)
+		return err
+	}
+	w := &Writer{}
+	n, err := w.Write("hello")
+	println(n,err)
+	`, "", nil)
+	cltest.Expect(t, `
+	import "fmt"
+	type Writer struct {
+	}
+	func (w *Writer) Write(data string) (err error) {
+		return fmt.Println(data)
+	}
+	w := &Writer{}
+	n, err := w.Write("hello")
+	println(n,err)
+	`, "", nil)
+}
+
 type testData struct {
 	clause string
 	want   string

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -807,6 +807,20 @@ func TestIsNoExecCtx(t *testing.T) {
 	println("values:", fns[0](), fns[1](), fns[2]())`, "values: 3 15 777\n")
 }
 
+func TestResult(t *testing.T) {
+	cltest.Expect(t, `
+	import "fmt"
+	type Writer struct {
+	}
+	func (w *Writer) Write(data string) (n int, err error) {
+		return fmt.Println(data)
+	}
+	w := &Writer{}
+	n, err := w.Write("hello")
+	println(n,err)
+	`, "hello\n6 <nil>\n")
+}
+
 type testData struct {
 	clause string
 	want   string

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -527,6 +527,18 @@ func compileReturnStmt(ctx *blockCtx, expr *ast.ReturnStmt) {
 		compileExpr(ctx, ret)()
 	}
 	n := len(rets)
+	if n == 1 && ctx.infer.Len() == 1 {
+		if ret, ok := ctx.infer.Get(-1).(*funcResults); ok {
+			n := ret.NumValues()
+			if fun.NumOut() != n {
+				log.Panicln("compileReturnStmt failed: mismatched count of return values -", fun.Name())
+			}
+			ctx.infer.SetLen(0)
+			ctx.out.Return(int32(n))
+			return
+		}
+	}
+
 	if fun.NumOut() != n {
 		log.Panicln("compileReturnStmt failed: mismatched count of return values -", fun.Name())
 	}

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -229,10 +229,12 @@ func (p *Builder) Return(n int32) *Builder {
 		if n > 0 {
 			arity := int(n)
 			args := p.rhs.GetArgs(arity)
-			results = make([]ast.Expr, n)
-			for i, arg := range args {
-				results[i] = arg.(ast.Expr)
+			for _, arg := range args {
+				if v, ok := arg.(ast.Expr); ok {
+					results = append(results, v)
+				}
 			}
+			arity = len(results)
 			p.rhs.PopN(arity)
 		}
 		stmt = &ast.ReturnStmt{Results: results}

--- a/exec/golang/testdata/30.result/result.gop
+++ b/exec/golang/testdata/30.result/result.gop
@@ -1,0 +1,34 @@
+import "fmt"
+
+type Writer struct {
+}
+
+func (w *Writer) Write(data string) (n int, err error) {
+	return fmt.Println(data)
+}
+
+func myint(n int) int {
+	return n
+}
+
+func myerr(err error) error {
+	return err
+}
+
+func (w *Writer) Write2(data string) (int, error) {
+	fmt.Println(data)
+	return len(data) + 1, nil
+}
+
+func (w *Writer) Write3(data string) (int, error) {
+	n, err := fmt.Println(data)
+	return myint(n), myerr(err)
+}
+
+w := &Writer{}
+n, err := w.Write("hello")
+println(n, err)
+n, err = w.Write2("hello")
+println(n, err)
+n, err = w.Write3("hello")
+println(n, err)


### PR DESCRIPTION
Go+ code
```
import "fmt"
type Writer struct {
}
func (w *Writer) Write(data string) (n int, err error) {
	return fmt.Println(data)
}
```
generate Golang code
```
package main

import fmt "fmt"

type Writer struct {
}

var (
	w   *Writer
	err error
	n   int
)

func main() { 
//line ./main.gop:8
	w = &Writer{}
//line ./main.gop:9
	n, err = w.Write("hello")
//line ./main.gop:10
	fmt.Println(n, err)
}
func (recv *Writer) Write(_arg_0 string) (n int, err error) { 
//line ./main.gop:6
	return fmt.Println(_arg_0)
}
```