### PR TITLE
fix #600, generate golang function params use defined variable name

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -360,18 +360,18 @@ func (p *blockCtx) findVar(name string) (addr iVar, err error) {
 	return nil, ErrSymbolNotVariable
 }
 
-func (p *blockCtx) insertFuncVars(in []reflect.Type, args []string, rets []exec.Var) {
-	n := len(args)
+func (p *blockCtx) insertFuncVars(in []exec.Var, rets []exec.Var) {
+	n := len(in)
 	if n > 0 {
 		for i := n - 1; i >= 0; i-- {
-			name := args[i]
+			name := in[i].Name()
 			if name == "" { // unnamed argument
 				continue
 			}
 			if p.exists(name) {
 				log.Panicln("insertStkVars failed: symbol exists -", name)
 			}
-			p.syms[name] = &stackVar{index: int32(i - n), typ: in[i]}
+			p.syms[name] = &stackVar{index: int32(i - n), typ: in[i].Type()}
 		}
 	}
 	for _, ret := range rets {

--- a/cl/context.go
+++ b/cl/context.go
@@ -352,10 +352,10 @@ func (p *blockCtx) insertFuncVars(in []exec.Var, rets []exec.Var) {
 	n := len(in)
 	if n > 0 {
 		for i := n - 1; i >= 0; i-- {
-			name := in[i].Name()
-			if name == "" { // unnamed argument
+			if in[i].IsUnnamed() { // unnamed argument
 				continue
 			}
+			name := in[i].Name()
 			if p.exists(name) {
 				log.Panicln("insertStkVars failed: symbol exists -", name)
 			}
@@ -363,7 +363,7 @@ func (p *blockCtx) insertFuncVars(in []exec.Var, rets []exec.Var) {
 		}
 	}
 	for _, ret := range rets {
-		if ret.IsUnnamedOut() {
+		if ret.IsUnnamed() {
 			continue
 		}
 		p.syms[ret.Name()] = &execVar{ret}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1036,7 +1036,7 @@ func compileErrWrapExpr(ctx *blockCtx, v *ast.ErrWrapExpr) func() {
 				File: pos.Filename,
 				Line: pos.Line,
 			}
-			ctx.out.ErrWrap(fun, nx, retErr, frame, narg)
+			ctx.out.ErrWrap(nx, retErr, frame, narg, fun)
 			return
 		}
 		if nx != 2 {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1036,7 +1036,7 @@ func compileErrWrapExpr(ctx *blockCtx, v *ast.ErrWrapExpr) func() {
 				File: pos.Filename,
 				Line: pos.Line,
 			}
-			ctx.out.ErrWrap(nx, retErr, frame, narg)
+			ctx.out.ErrWrap(fun, nx, retErr, frame, narg)
 			return
 		}
 		if nx != 2 {

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -77,10 +77,10 @@ type FuncInfo interface {
 	Type() reflect.Type
 
 	// Args sets argument types of a Go+ function.
-	Args(in ...reflect.Type) FuncInfo
+	Args(in ...Var) FuncInfo
 
 	// Vargs sets argument types of a variadic Go+ function.
-	Vargs(in ...reflect.Type) FuncInfo
+	Vargs(in ...Var) FuncInfo
 
 	// Return sets return types of a Go+ function.
 	Return(out ...Var) FuncInfo
@@ -213,7 +213,7 @@ type Builder interface {
 	WrapIfErr(nret int, l Label) Builder
 
 	// ErrWrap instr
-	ErrWrap(nret int, retErr Var, frame *errors.Frame, narg int) Builder
+	ErrWrap(fun FuncInfo, nret int, retErr Var, frame *errors.Frame, narg int) Builder
 
 	// ForPhrase instr
 	ForPhrase(f ForPhrase, key, val Var, hasExecCtx ...bool) Builder

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -207,7 +207,7 @@ type Builder interface {
 	WrapIfErr(nret int, l Label) Builder
 
 	// ErrWrap instr
-	ErrWrap(fun FuncInfo, nret int, retErr Var, frame *errors.Frame, narg int) Builder
+	ErrWrap(nret int, retErr Var, frame *errors.Frame, narg int, fun FuncInfo) Builder
 
 	// ForPhrase instr
 	ForPhrase(f ForPhrase, key, val Var, hasExecCtx ...bool) Builder

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -33,8 +33,8 @@ type Var interface {
 	// Type returns the variable type.
 	Type() reflect.Type
 
-	// IsUnnamedOut returns if variable unnamed or not.
-	IsUnnamedOut() bool
+	// IsUnnamed returns if variable unnamed or not.
+	IsUnnamed() bool
 }
 
 // Label represents a label.

--- a/exec/bytecode/flow.go
+++ b/exec/bytecode/flow.go
@@ -214,7 +214,7 @@ func execErrWrap(i Instr, ctx *Context) {
 }
 
 // ErrWrap instr
-func (p *Builder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int) *Builder {
+func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) *Builder {
 	code := p.code
 	idx := len(code.errWraps)
 	code.errWraps = append(

--- a/exec/bytecode/flow.go
+++ b/exec/bytecode/flow.go
@@ -214,7 +214,7 @@ func execErrWrap(i Instr, ctx *Context) {
 }
 
 // ErrWrap instr
-func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) *Builder {
+func (p *Builder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int, fun exec.FuncInfo) *Builder {
 	code := p.code
 	idx := len(code.errWraps)
 	code.errWraps = append(

--- a/exec/bytecode/flow_test.go
+++ b/exec/bytecode/flow_test.go
@@ -55,7 +55,7 @@ func TestErrWrap(t *testing.T) {
 		Push(123).
 		Push("not found").
 		CallGoFuncv(errorf, 1, 1).
-		ErrWrap(2, nil, frame, 3).
+		ErrWrap(nil, 2, nil, frame, 3).
 		Resolve()
 
 	ctx := NewContext(code)
@@ -88,7 +88,7 @@ func TestErrWrap1(t *testing.T) {
 		Push(123).
 		Push("not found").
 		CallGoFuncv(errorf, 1, 1).
-		ErrWrap(2, retErr, frame, 3).
+		ErrWrap(nil, 2, retErr, frame, 3).
 		Resolve()
 
 	ctx := NewContext(code)
@@ -110,7 +110,7 @@ func TestErrWrap2(t *testing.T) {
 	code := newBuilder().
 		Push(123).
 		Push(nil).
-		ErrWrap(2, nil, nil, 0).
+		ErrWrap(nil, 2, nil, nil, 0).
 		Resolve()
 
 	ctx := NewContext(code)

--- a/exec/bytecode/flow_test.go
+++ b/exec/bytecode/flow_test.go
@@ -55,7 +55,7 @@ func TestErrWrap(t *testing.T) {
 		Push(123).
 		Push("not found").
 		CallGoFuncv(errorf, 1, 1).
-		ErrWrap(nil, 2, nil, frame, 3).
+		ErrWrap(2, nil, frame, 3, nil).
 		Resolve()
 
 	ctx := NewContext(code)
@@ -88,7 +88,7 @@ func TestErrWrap1(t *testing.T) {
 		Push(123).
 		Push("not found").
 		CallGoFuncv(errorf, 1, 1).
-		ErrWrap(nil, 2, retErr, frame, 3).
+		ErrWrap(2, retErr, frame, 3, nil).
 		Resolve()
 
 	ctx := NewContext(code)
@@ -110,7 +110,7 @@ func TestErrWrap2(t *testing.T) {
 	code := newBuilder().
 		Push(123).
 		Push(nil).
-		ErrWrap(nil, 2, nil, nil, 0).
+		ErrWrap(2, nil, nil, 0, nil).
 		Resolve()
 
 	ctx := NewContext(code)

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -214,7 +214,7 @@ func (p *FuncInfo) Out(i int) *Var {
 // IsUnnamedOut returns if function results unnamed or not.
 func (p *FuncInfo) IsUnnamedOut() bool {
 	if p.numOut > 0 {
-		return p.vlist[0].IsUnnamedOut()
+		return p.vlist[0].IsUnnamed()
 	}
 	return false
 }

--- a/exec/bytecode/func_test.go
+++ b/exec/bytecode/func_test.go
@@ -39,7 +39,7 @@ func TestFunc(t *testing.T) {
 		Return(-1).
 		DefineFunc(
 			foo.Return(ret).
-				Args(TyString, TyString)).
+				Args(NewVar(TyString, "a"), NewVar(TyString, "b"))).
 		Load(-2).
 		Load(-1).
 		CallGoFunc(strcat, 2).
@@ -93,7 +93,7 @@ func TestFuncv(t *testing.T) {
 		Return(-1).
 		DefineFunc(
 			foo.Return(ret1).
-				Vargs(TyString, tyInterfaceSlice)).
+				Vargs(NewVar(TyString, "a"), NewVar(tyInterfaceSlice, "b"))).
 		DefineVar(format, args).
 		Load(-2).
 		StoreVar(format).
@@ -106,7 +106,7 @@ func TestFuncv(t *testing.T) {
 		EndFunc(foo).
 		DefineFunc(
 			bar.Return(ret2).
-				Vargs(TyString, tyInterfaceSlice)).
+				Vargs(NewVar(TyString, "a"), NewVar(tyInterfaceSlice, "b"))).
 		Load(-2).
 		Load(-1).
 		CallFuncv(foo, -1). // foo(format, args...)
@@ -155,14 +155,14 @@ func TestFuncLargeArity(t *testing.T) {
 		Return(-1).
 		DefineFunc(
 			bar.Return(ret1).
-				Vargs(tyStringSlice)).
+				Vargs(NewVar(tyStringSlice, "a"))).
 		Load(-1).
 		CallGoFuncv(GoFuncvAddr(sprint), 1, -1).
 		StoreVar(ret1).
 		EndFunc(bar).
 		DefineFunc(
 			foo.Return(ret2).
-				Vargs(tyStringSlice)).
+				Vargs(NewVar(tyStringSlice, "b"))).
 		Load(-1).
 		CallFuncv(bar, 1, -1).
 		StoreVar(ret2).
@@ -192,7 +192,7 @@ func TestClosure(t *testing.T) {
 		Return(-1).
 		DefineFunc(
 			foo.Return(ret).
-				Args(TyString, TyString)).
+				Args(NewVar(TyString, "a"), NewVar(TyString, "b"))).
 		Load(-2).
 		Load(-1).
 		CallGoFunc(strcat, 2).
@@ -229,7 +229,7 @@ func TestClosure2(t *testing.T) {
 		Return(-1).
 		DefineFunc(
 			foo.Return(ret1).
-				Vargs(TyString, tyInterfaceSlice)).
+				Vargs(NewVar(TyString, "a"), NewVar(tyInterfaceSlice, "b"))).
 		Load(-2).
 		Load(-1).
 		CallGoFuncv(sprintf, 2, -1). // sprintf(format, args...)
@@ -237,7 +237,7 @@ func TestClosure2(t *testing.T) {
 		EndFunc(foo).
 		DefineFunc(
 			bar.Return(ret2).
-				Vargs(TyString, tyInterfaceSlice)).
+				Vargs(NewVar(TyString, "a"), NewVar(tyInterfaceSlice, "b"))).
 		Load(-2).
 		Load(-1).
 		Closure(foo).
@@ -275,7 +275,7 @@ func TestGoClosure(t *testing.T) {
 		Return(-1).
 		DefineFunc(
 			foo.Return(ret1).
-				Vargs(TyString, tyInterfaceSlice)).
+				Vargs(NewVar(TyString, "a"), NewVar(tyInterfaceSlice, "b"))).
 		Load(-2).
 		Load(-1).
 		CallGoFuncv(sprintf, 2, -1). // sprintf(format, args...)
@@ -283,7 +283,7 @@ func TestGoClosure(t *testing.T) {
 		EndFunc(foo).
 		DefineFunc(
 			bar.Return(ret2).
-				Vargs(TyString, tyInterfaceSlice)).
+				Vargs(NewVar(TyString, "a"), NewVar(tyInterfaceSlice, "b"))).
 		Load(-2).
 		Load(-1).
 		GoClosure(foo).

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -39,13 +39,13 @@ func (p *iFuncInfo) Out(i int) exec.Var {
 }
 
 // Args sets argument types of a Go+ function.
-func (p *iFuncInfo) Args(in ...reflect.Type) exec.FuncInfo {
+func (p *iFuncInfo) Args(in ...exec.Var) exec.FuncInfo {
 	((*FuncInfo)(p)).Args(in...)
 	return p
 }
 
 // Vargs sets argument types of a variadic Go+ function.
-func (p *iFuncInfo) Vargs(in ...reflect.Type) exec.FuncInfo {
+func (p *iFuncInfo) Vargs(in ...exec.Var) exec.FuncInfo {
 	((*FuncInfo)(p)).Vargs(in...)
 	return p
 }
@@ -145,8 +145,8 @@ func (p *iBuilder) WrapIfErr(nret int, l exec.Label) exec.Builder {
 }
 
 // ErrWrap instr
-func (p *iBuilder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int) exec.Builder {
-	((*Builder)(p)).ErrWrap(nret, retErr, frame, narg)
+func (p *iBuilder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) exec.Builder {
+	((*Builder)(p)).ErrWrap(fun, nret, retErr, frame, narg)
 	return p
 }
 

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -145,8 +145,8 @@ func (p *iBuilder) WrapIfErr(nret int, l exec.Label) exec.Builder {
 }
 
 // ErrWrap instr
-func (p *iBuilder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) exec.Builder {
-	((*Builder)(p)).ErrWrap(fun, nret, retErr, frame, narg)
+func (p *iBuilder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int, fun exec.FuncInfo) exec.Builder {
+	((*Builder)(p)).ErrWrap(nret, retErr, frame, narg, fun)
 	return p
 }
 

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -263,8 +263,11 @@ func (p *Var) Name() string {
 	return p.name[1:]
 }
 
-// IsUnnamedOut returns if variable unnamed or not.
-func (p *Var) IsUnnamedOut() bool {
+// IsUnnamed returns if variable unnamed or not.
+func (p *Var) IsUnnamed() bool {
+	if len(p.name) <= 1 {
+		return true
+	}
 	c := p.name[1]
 	return c >= '0' && c <= '9'
 }

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -129,7 +129,7 @@ func NewBuilder(pkgName string, code *Code, fset *token.FileSet) *Builder {
 
 func (p *Builder) autoIdent() string {
 	p.identBase++
-	return "_gop_" + strconv.Itoa(p.identBase)
+	return "_gop_id_" + strconv.Itoa(p.identBase)
 }
 
 var (

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -20,7 +20,6 @@ import (
 	"go/ast"
 	"go/token"
 	"reflect"
-	"strconv"
 
 	"github.com/goplus/gop/exec.spec"
 	"github.com/goplus/gop/exec/golang/internal/go/printer"
@@ -293,8 +292,4 @@ func toFuncType(p *Builder, typ *FuncInfo) *ast.FuncType {
 		Params:  &ast.FieldList{Opening: 1, List: params, Closing: 1},
 		Results: &ast.FieldList{Opening: opening, List: results, Closing: opening},
 	}
-}
-
-func toArg(i int) string {
-	return "_arg_" + strconv.Itoa(i)
 }

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -148,7 +148,7 @@ func (p *FuncInfo) Return(out ...exec.Var) exec.FuncInfo {
 // IsUnnamedOut returns if function results unnamed or not.
 func (p *FuncInfo) IsUnnamedOut() bool {
 	if len(p.out) > 0 {
-		return p.out[0].IsUnnamedOut()
+		return p.out[0].IsUnnamed()
 	}
 	return false
 }

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -274,30 +274,18 @@ func toFuncType(p *Builder, typ *FuncInfo) *ast.FuncType {
 		}
 		for i := 0; i < numIn; i++ {
 			in := typ.in[i].(*Var)
-			var name string
-			if !in.IsUnnamedOut() {
-				name = in.name
-			}
-			params[i] = Field(p, name, in.typ, "", false)
+			params[i] = Field(p, getVarInName(in), in.typ, "", false)
 		}
 		if variadic {
 			in := typ.in[numIn].(*Var)
-			var name string
-			if !in.IsUnnamedOut() {
-				name = in.name
-			}
-			params[numIn] = Field(p, name, in.typ, "", true)
+			params[numIn] = Field(p, getVarInName(in), in.typ, "", true)
 		}
 	}
 	if numOut > 0 {
 		results = make([]*ast.Field, numOut)
 		for i := 0; i < numOut; i++ {
 			out := typ.Out(i).(*Var)
-			name := out.name
-			if out.IsUnnamedOut() {
-				name = "_gop_ret_" + out.name
-			}
-			results[i] = Field(p, name, out.typ, "", false)
+			results[i] = Field(p, getVarOutName(out), out.typ, "", false)
 		}
 		opening++
 	}

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -274,18 +274,30 @@ func toFuncType(p *Builder, typ *FuncInfo) *ast.FuncType {
 		}
 		for i := 0; i < numIn; i++ {
 			in := typ.in[i].(*Var)
-			params[i] = Field(p, in.ValidName(), in.typ, "", false)
+			var name string
+			if !in.IsUnnamedOut() {
+				name = in.name
+			}
+			params[i] = Field(p, name, in.typ, "", false)
 		}
 		if variadic {
 			in := typ.in[numIn].(*Var)
-			params[numIn] = Field(p, in.ValidName(), in.typ, "", true)
+			var name string
+			if !in.IsUnnamedOut() {
+				name = in.name
+			}
+			params[numIn] = Field(p, name, in.typ, "", true)
 		}
 	}
 	if numOut > 0 {
 		results = make([]*ast.Field, numOut)
 		for i := 0; i < numOut; i++ {
 			out := typ.Out(i).(*Var)
-			results[i] = Field(p, out.ValidName(), out.typ, "", false)
+			name := out.name
+			if out.IsUnnamedOut() {
+				name = "_gop_ret_" + out.name
+			}
+			results[i] = Field(p, name, out.typ, "", false)
 		}
 		opening++
 	}

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -155,8 +155,8 @@ func (p *iBuilder) WrapIfErr(nret int, l exec.Label) exec.Builder {
 }
 
 // ErrWrap instr
-func (p *iBuilder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) exec.Builder {
-	((*Builder)(p)).ErrWrap(fun, nret, retErr, frame, narg)
+func (p *iBuilder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int, fun exec.FuncInfo) exec.Builder {
+	((*Builder)(p)).ErrWrap(nret, retErr, frame, narg, fun)
 	return p
 }
 

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -155,8 +155,8 @@ func (p *iBuilder) WrapIfErr(nret int, l exec.Label) exec.Builder {
 }
 
 // ErrWrap instr
-func (p *iBuilder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int) exec.Builder {
-	((*Builder)(p)).ErrWrap(nret, retErr, frame, narg)
+func (p *iBuilder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) exec.Builder {
+	((*Builder)(p)).ErrWrap(fun, nret, retErr, frame, narg)
 	return p
 }
 

--- a/exec/golang/stmt.go
+++ b/exec/golang/stmt.go
@@ -194,7 +194,12 @@ func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *e
 	frameArgs[4] = StringConst(frame.Pkg)
 	frameArgs[5] = StringConst(frame.Func)
 	for i := 0; i < narg; i++ {
-		frameArgs[6+i] = Ident(fun.(*FuncInfo).in[i].(*Var).ValidName()) //Ident(toArg(i))
+		v := fun.(*FuncInfo).in[i].(*Var)
+		var name string
+		if !v.IsUnnamedOut() {
+			name = v.name
+		}
+		frameArgs[6+i] = Ident(name) //Ident(toArg(i))
 	}
 	frameErr := &ast.CallExpr{Fun: frameFun, Args: frameArgs}
 	var body *ast.BlockStmt

--- a/exec/golang/stmt.go
+++ b/exec/golang/stmt.go
@@ -195,16 +195,12 @@ func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *e
 	frameArgs[5] = StringConst(frame.Func)
 	for i := 0; i < narg; i++ {
 		v := fun.(*FuncInfo).in[i].(*Var)
-		var name string
-		if !v.IsUnnamedOut() {
-			name = v.name
-		}
-		frameArgs[6+i] = Ident(name) //Ident(toArg(i))
+		frameArgs[6+i] = Ident(getVarInName(v)) //Ident(toArg(i))
 	}
 	frameErr := &ast.CallExpr{Fun: frameFun, Args: frameArgs}
 	var body *ast.BlockStmt
 	if retErr != nil {
-		outErr := Ident(retErr.Name())
+		outErr := Ident(getVarOutName(retErr.(*Var)))
 		assignErr := &ast.AssignStmt{
 			Lhs: []ast.Expr{outErr},
 			Tok: token.ASSIGN,

--- a/exec/golang/stmt.go
+++ b/exec/golang/stmt.go
@@ -183,7 +183,7 @@ func (p *Builder) wrapCall(nret int) []ast.Expr {
 }
 
 // ErrWrap instr
-func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) *Builder {
+func (p *Builder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int, fun exec.FuncInfo) *Builder {
 	args := p.wrapCall(nret)
 	frameFun := p.GoSymIdent("github.com/qiniu/x/errors", "NewFrame")
 	frameArgs := make([]ast.Expr, narg+6)
@@ -195,7 +195,7 @@ func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *e
 	frameArgs[5] = StringConst(frame.Func)
 	for i := 0; i < narg; i++ {
 		v := fun.(*FuncInfo).in[i].(*Var)
-		frameArgs[6+i] = Ident(getVarInName(v)) //Ident(toArg(i))
+		frameArgs[6+i] = Ident(getVarInName(v))
 	}
 	frameErr := &ast.CallExpr{Fun: frameFun, Args: frameArgs}
 	var body *ast.BlockStmt

--- a/exec/golang/stmt.go
+++ b/exec/golang/stmt.go
@@ -183,7 +183,7 @@ func (p *Builder) wrapCall(nret int) []ast.Expr {
 }
 
 // ErrWrap instr
-func (p *Builder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg int) *Builder {
+func (p *Builder) ErrWrap(fun exec.FuncInfo, nret int, retErr exec.Var, frame *errors.Frame, narg int) *Builder {
 	args := p.wrapCall(nret)
 	frameFun := p.GoSymIdent("github.com/qiniu/x/errors", "NewFrame")
 	frameArgs := make([]ast.Expr, narg+6)
@@ -194,7 +194,7 @@ func (p *Builder) ErrWrap(nret int, retErr exec.Var, frame *errors.Frame, narg i
 	frameArgs[4] = StringConst(frame.Pkg)
 	frameArgs[5] = StringConst(frame.Func)
 	for i := 0; i < narg; i++ {
-		frameArgs[6+i] = Ident(toArg(i))
+		frameArgs[6+i] = Ident(fun.(*FuncInfo).in[i].(*Var).ValidName()) //Ident(toArg(i))
 	}
 	frameErr := &ast.CallExpr{Fun: frameFun, Args: frameArgs}
 	var body *ast.BlockStmt

--- a/exec/golang/testdata/13.func/func.gop
+++ b/exec/golang/testdata/13.func/func.gop
@@ -16,6 +16,10 @@ func bar(foo func(string, ...interface{}) (int, error)) {
 	foo("Hello, %v!\n", "Go+")
 }
 
+func unnamed(int) int {
+	return 100
+}
+
 func() {
 	println("hello,go+")
 }()
@@ -23,3 +27,4 @@ func() {
 bar(printf)
 fmt.Println(foo("Hello, world???"))
 fmt.Println(printf("Hello, %v\n", "Go+"))
+fmt.Println(unnamed(1))

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -72,7 +72,7 @@ func Field(p *Builder, name string, typ reflect.Type, tag string, ellipsis bool)
 	var names []*ast.Ident
 	var ftag *ast.BasicLit
 	var typExpr ast.Expr
-	if name != "" {
+	if name != "" && !(name[0] >= '0' && name[0] <= '9') {
 		names = []*ast.Ident{Ident(name)}
 	}
 	if tag != "" {

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -72,7 +72,7 @@ func Field(p *Builder, name string, typ reflect.Type, tag string, ellipsis bool)
 	var names []*ast.Ident
 	var ftag *ast.BasicLit
 	var typExpr ast.Expr
-	if name != "" && !(name[0] >= '0' && name[0] <= '9') {
+	if name != "" {
 		names = []*ast.Ident{Ident(name)}
 	}
 	if tag != "" {

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -36,12 +36,6 @@ type Var struct {
 
 // NewVar creates a variable instance.
 func NewVar(typ reflect.Type, name string) *Var {
-	if name != "" {
-		c := name[0]
-		if c >= '0' && c <= '9' {
-			name = "_gop_ret_" + name
-		}
-	}
 	return &Var{typ: typ, name: name}
 }
 
@@ -69,13 +63,6 @@ func (p *Var) setScope(where *scopeCtx) {
 		panic("Var.setScope: variable already defined")
 	}
 	p.where = where
-}
-
-func (p *Var) ValidName() string {
-	if p.IsUnnamedOut() {
-		return ""
-	}
-	return p.name
 }
 
 // -----------------------------------------------------------------------------

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -49,8 +49,8 @@ func (p *Var) Name() string {
 	return p.name
 }
 
-// IsUnnamedOut returns if variable unnamed or not.
-func (p *Var) IsUnnamedOut() bool {
+// IsUnnamed returns if variable unnamed or not.
+func (p *Var) IsUnnamed() bool {
 	if p.name == "" {
 		return true
 	}
@@ -66,14 +66,14 @@ func (p *Var) setScope(where *scopeCtx) {
 }
 
 func getVarInName(v *Var) string {
-	if v.IsUnnamedOut() {
+	if v.IsUnnamed() {
 		return ""
 	}
 	return v.name
 }
 
 func getVarOutName(v *Var) string {
-	if v.IsUnnamedOut() {
+	if v.IsUnnamed() {
 		return "_gop_ret_" + v.name
 	}
 	return v.name
@@ -160,7 +160,7 @@ func (p *Builder) argIdent(idx int32) *ast.Ident {
 	} else {
 		v = p.cfun.in[i].(*Var)
 	}
-	if v.IsUnnamedOut() {
+	if v.IsUnnamed() {
 		return &ast.Ident{}
 	}
 	return Ident(v.name)

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -58,7 +58,7 @@ func (p *Var) Name() string {
 // IsUnnamedOut returns if variable unnamed or not.
 func (p *Var) IsUnnamedOut() bool {
 	if p.name == "" {
-		return false
+		return true
 	}
 	c := p.name[0]
 	return c >= '0' && c <= '9'

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -65,6 +65,20 @@ func (p *Var) setScope(where *scopeCtx) {
 	p.where = where
 }
 
+func getVarInName(v *Var) string {
+	if v.IsUnnamedOut() {
+		return ""
+	}
+	return v.name
+}
+
+func getVarOutName(v *Var) string {
+	if v.IsUnnamedOut() {
+		return "_gop_ret_" + v.name
+	}
+	return v.name
+}
+
 // -----------------------------------------------------------------------------
 
 type scopeCtx struct {


### PR DESCRIPTION
fix #600 , exec/golang function argument use defined named, function return use defined named or "_gop_ret_n"

Go+ code
```
package main

func test1(a,b int) (int) {
	return a+b
}
func test2(a,b int) (n int) {
	n = a+b
	return
}
test1(100,200)
test2(100,200)
```
generate Golang code
```
package main

func main() { 
//line ./main.gop:11
	test1(100, 200)
//line ./main.gop:12
	test2(100, 200)
}
func test2(a int, b int) (n int) { 
//line ./main.gop:8
	n = a + b
//line ./main.gop:9
	return
}
func test1(a int, b int) (_gop_ret_1 int) { 
//line ./main.gop:5
	return a + b
}
```