### PR TITLE
fix #606, support underscore

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -372,7 +372,7 @@ func (p *blockCtx) insertFuncVars(in []reflect.Type, args []string, rets []exec.
 }
 
 func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *execVar {
-	if p.exists(name) {
+	if name != "_" && p.exists(name) {
 		log.Panicln("insertVar failed: symbol exists -", name)
 	}
 	v := p.NewVar(typ, name)

--- a/cl/context.go
+++ b/cl/context.go
@@ -187,6 +187,7 @@ type blockCtx struct {
 	fieldStructType reflect.Type
 	fieldIndex      []int
 	fieldExprX      func()
+	underscore      int
 }
 
 // function block ctx

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -173,6 +173,9 @@ var addrops = map[token.Token]exec.AddrOperator{
 }
 
 func compileIdent(ctx *blockCtx, name string) func() {
+	if name == "_" {
+		log.Panicln("cannot use _ as value")
+	}
 	if sym, ok := ctx.find(name); ok {
 		switch v := sym.(type) {
 		case *execVar:

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -104,22 +104,30 @@ func compileExpr(ctx *blockCtx, expr ast.Expr) func() {
 func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 	in := ctx.infer.Get(-1)
 	addr, err := ctx.findVar(name)
-	if mode == lhsDefine {
-		addr, err = ctx.getCtxVar(name)
-		if addr != nil {
-			log.Panicf("compileIdentLHS failed: %s redeclared in this block\n", name)
+	if name == "_" {
+		ctx.underscore++
+		if err == ErrNotFound {
+			addr = ctx.insertVar(name, exec.TyEmptyInterface)
 		}
-	}
-	if err == nil {
-		if mode == lhsDefine && !addr.inCurrentCtx(ctx) {
-			log.Warn("requireVar: variable is shadowed -", name)
-		}
-	} else if mode == lhsAssign || err != ErrNotFound {
-		log.Panicln("compileIdentLHS failed:", err, "-", name)
 	} else {
-		typ := boundType(in.(iValue))
-		addr = ctx.insertVar(name, typ)
+		if mode == lhsDefine {
+			addr, err = ctx.getCtxVar(name)
+			if addr != nil {
+				log.Panicf("compileIdentLHS failed: %s redeclared in this block\n", name)
+			}
+		}
+		if err == nil {
+			if mode == lhsDefine && !addr.inCurrentCtx(ctx) {
+				log.Warn("requireVar: variable is shadowed -", name)
+			}
+		} else if mode == lhsAssign || err != ErrNotFound {
+			log.Panicln("compileIdentLHS failed:", err, "-", name)
+		} else {
+			typ := boundType(in.(iValue))
+			addr = ctx.insertVar(name, typ)
+		}
 	}
+
 	typ := addr.getType()
 	if ctx.indirect {
 		typ = typ.Elem()

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -103,11 +103,14 @@ func compileExpr(ctx *blockCtx, expr ast.Expr) func() {
 
 func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 	in := ctx.infer.Get(-1)
-	addr, err := ctx.findVar(name)
+	var addr iVar
 	if name == "_" {
 		ctx.underscore++
-		addr = ctx.insertVar(name, exec.TyEmptyInterface)
+		typ := boundType(in.(iValue))
+		addr = ctx.insertVar(name, typ)
 	} else {
+		var err error
+		addr, err = ctx.findVar(name)
 		if mode == lhsDefine {
 			addr, err = ctx.getCtxVar(name)
 			if addr != nil {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -106,9 +106,7 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 	addr, err := ctx.findVar(name)
 	if name == "_" {
 		ctx.underscore++
-		if err == ErrNotFound {
-			addr = ctx.insertVar(name, exec.TyEmptyInterface)
-		}
+		addr = ctx.insertVar(name, exec.TyEmptyInterface)
 	} else {
 		if mode == lhsDefine {
 			addr, err = ctx.getCtxVar(name)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -907,6 +907,12 @@ func TestBadUnderscore(t *testing.T) {
 	`, "", nil)
 }
 
+func TestBadVar(t *testing.T) {
+	cltest.Expect(t, `
+	var a int
+	var a string`, "", nil)
+}
+
 type testData struct {
 	clause string
 	want   string

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -893,12 +893,16 @@ func TestUnderscore(t *testing.T) {
 
 func TestBadUnderscore(t *testing.T) {
 	cltest.Expect(t, `
+	println(_)
+	`, "", nil)
+	cltest.Expect(t, `
 	_ := 100
 	`, "", nil)
 	cltest.Expect(t, `
 	_,_ := 100,"hello"
 	`, "", nil)
 	cltest.Expect(t, `
+	import "fmt"
 	_, _ := fmt.Println("Hello World")
 	`, "", nil)
 }

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -911,6 +911,8 @@ func TestBadVar(t *testing.T) {
 	cltest.Expect(t, `
 	var a int
 	var a string`, "", nil)
+	cltest.Expect(t, `
+	a = 10`, "", nil)
 }
 
 type testData struct {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -878,6 +878,31 @@ func TestBadResult(t *testing.T) {
 	`, "", nil)
 }
 
+func TestUnderscore(t *testing.T) {
+	cltest.Expect(t, `
+	import "fmt"
+	var _ int
+	var _ string
+	_ = 100
+	_ = "hello"
+	_, a := 100,"world"
+	b, _ := fmt.Println("Hello World")
+	println(a,b)
+	`, "Hello World\nworld 12\n")
+}
+
+func TestBadUnderscore(t *testing.T) {
+	cltest.Expect(t, `
+	_ := 100
+	`, "", nil)
+	cltest.Expect(t, `
+	_,_ := 100,"hello"
+	`, "", nil)
+	cltest.Expect(t, `
+	_, _ := fmt.Println("Hello World")
+	`, "", nil)
+}
+
 type testData struct {
 	clause string
 	want   string

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -637,7 +637,7 @@ func compileAssignStmt(ctx *blockCtx, expr *ast.AssignStmt) {
 		compileExprLHS(ctx, expr.Lhs[i], expr.Tok)
 	}
 	if ctx.underscore == count && expr.Tok == token.DEFINE {
-		log.Panic("no new variables on left side of :=")
+		log.Panicln("no new variables on left side of :=")
 	}
 }
 

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -631,8 +631,13 @@ func compileAssignStmt(ctx *blockCtx, expr *ast.AssignStmt) {
 	if ctx.infer.Len() != len(expr.Lhs) {
 		log.Panicln("compileAssignStmt: assign statement has mismatched variables count -", ctx.infer.Len())
 	}
+	count := len(expr.Lhs)
+	ctx.underscore = 0
 	for i := len(expr.Lhs) - 1; i >= 0; i-- {
 		compileExprLHS(ctx, expr.Lhs[i], expr.Tok)
+	}
+	if ctx.underscore == count && expr.Tok == token.DEFINE {
+		log.Panic("no new variables on left side of :=")
 	}
 }
 

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -204,6 +204,7 @@ func TestGoField(t *testing.T) {
 
 import (
 	fmt "fmt"
+	golang "github.com/goplus/gop/exec/golang"
 	pkg_field "pkg_field"
 )
 

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -263,10 +263,12 @@ func main() {
 	gtyp := reflect.TypeOf(gRect)
 	ytyp := reflect.TypeOf(rc)
 	y := NewVar(ytyp, "y")
+	u := NewVar(exec.TyInt, "_")
 	b := NewBuilder("main", nil, nil)
 
 	code := b.Interface().
-		DefineVar(y). // y
+		DefineVar(y). // var y testRect
+		DefineVar(u). // var _ int
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		LoadGoVar(x2).
 		StoreVar(y). // y = pkg_field.Rect2

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -118,7 +118,16 @@ func (p *scopeCtx) initStmts() {
 
 // DefineVar defines variables.
 func (p *Builder) DefineVar(vars ...exec.Var) *Builder {
-	p.addVar(vars...)
+	var vlist []exec.Var
+	for _, v := range vars {
+		if pkgPath := v.Type().PkgPath(); pkgPath != "" {
+			p.Import(pkgPath)
+		} else if v.Name() == "_" {
+			continue
+		}
+		vlist = append(vlist, v)
+	}
+	p.addVar(vlist...)
 	return p
 }
 


### PR DESCRIPTION
fix #606, support underscore
Go+ code
```
import (
	"bytes"
	"fmt"
)

var _ int
var _ int
var _ float32
var _ bytes.Buffer
_ = 100
_ = "hello"
_, n1 := 100,200
n2, _ := fmt.Println("Hello World")
println(n1,n2)
println("hello")
```
generate Golang code
```
package main

import (
	bytes "bytes"
	fmt "fmt"
)

var (
	_  bytes.Buffer
	n1 int
	n2 int
)

func main() { 
//line ./main.gop:11
	_ = 100
//line ./main.gop:12
	_ = "hello"
//line ./main.gop:13
	_, n1 = 100, 200
//line ./main.gop:14
	n2, _ = fmt.Println("Hello World")
//line ./main.gop:15
	fmt.Println(n1, n2)
//line ./main.gop:16
	fmt.Println("hello")
}
```