### PR TITLE
cl: fix #608, support struct method closure

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1151,7 +1151,11 @@ func compileStarExprLHS(ctx *blockCtx, v *ast.StarExpr, mode compileMode) {
 func methodToClosure(ctx *blockCtx, fun *ast.SelectorExpr, fDecl *funcDecl) *funcDecl {
 	typ := &ast.FuncType{Params: &ast.FieldList{}, Results: fDecl.typ.Results}
 	var args []ast.Expr
+	var ellipsis bool
 	for i, field := range fDecl.typ.Params.List {
+		if _, ok := field.Type.(*ast.Ellipsis); ok {
+			ellipsis = true
+		}
 		if field.Names != nil {
 			for _, name := range field.Names {
 				args = append(args, name)
@@ -1168,6 +1172,9 @@ func methodToClosure(ctx *blockCtx, fun *ast.SelectorExpr, fDecl *funcDecl) *fun
 	}
 	var body *ast.BlockStmt
 	call := &ast.CallExpr{Fun: fun, Args: args}
+	if ellipsis {
+		call.Ellipsis++
+	}
 	if typ.Results == nil {
 		body = &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{X: call}}}
 	} else {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1148,7 +1148,7 @@ func compileStarExprLHS(ctx *blockCtx, v *ast.StarExpr, mode compileMode) {
 	ctx.indirect = false
 }
 
-func methodToClosure(ctx *blockCtx, fun *ast.SelectorExpr, ftyp *ast.FuncType) *funcDecl {
+func funcToClosure(ctx *blockCtx, fun ast.Expr, ftyp *ast.FuncType) *funcDecl {
 	typ := &ast.FuncType{Params: &ast.FieldList{}, Results: ftyp.Results}
 	var args []ast.Expr
 	var ellipsis bool
@@ -1270,7 +1270,7 @@ func compileSelectorExpr(ctx *blockCtx, v *ast.SelectorExpr, compileByCallExpr b
 					return func() {}
 				} else {
 					ctx.infer.Pop()
-					decl := methodToClosure(ctx, v, fDecl.typ)
+					decl := funcToClosure(ctx, v, fDecl.typ)
 					ctx.use(decl)
 					ctx.infer.Push(newQlFunc(decl))
 					return func() {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1148,11 +1148,11 @@ func compileStarExprLHS(ctx *blockCtx, v *ast.StarExpr, mode compileMode) {
 	ctx.indirect = false
 }
 
-func methodToClosure(ctx *blockCtx, fun *ast.SelectorExpr, fDecl *funcDecl) *funcDecl {
-	typ := &ast.FuncType{Params: &ast.FieldList{}, Results: fDecl.typ.Results}
+func methodToClosure(ctx *blockCtx, fun *ast.SelectorExpr, ftyp *ast.FuncType) *funcDecl {
+	typ := &ast.FuncType{Params: &ast.FieldList{}, Results: ftyp.Results}
 	var args []ast.Expr
 	var ellipsis bool
-	for i, field := range fDecl.typ.Params.List {
+	for i, field := range ftyp.Params.List {
 		if _, ok := field.Type.(*ast.Ellipsis); ok {
 			ellipsis = true
 		}
@@ -1270,7 +1270,7 @@ func compileSelectorExpr(ctx *blockCtx, v *ast.SelectorExpr, compileByCallExpr b
 					return func() {}
 				} else {
 					ctx.infer.Pop()
-					decl := methodToClosure(ctx, v, fDecl)
+					decl := methodToClosure(ctx, v, fDecl.typ)
 					ctx.use(decl)
 					ctx.infer.Push(newQlFunc(decl))
 					return func() {

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -254,17 +254,23 @@ var testMethodClosure = `
 		fmt.Println(m.Sym)
 	}
 	
+	func (m *M) Test3(s string,n ...int) {
+		fmt.Println(m.Sym,s,n)
+	}
+	
 	m := &M{"#"}
 	foo := m.Test
 	foo2 := m.Test2
+	foo3 := m.Test3
 
 	x := "Hello, world!"
 	foo("x: ")
 	foo2(0)
+	foo3("a",100,200)
 `
 
 func TestMethodClosure(t *testing.T) {
-	cltest.Expect(t, testMethodClosure, "x: #Hello, world!\n#\n")
+	cltest.Expect(t, testMethodClosure, "x: #Hello, world!\n#\n# a [100 200]\n")
 }
 
 // -----------------------------------------------------------------------------

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -238,6 +238,35 @@ func TestClosure(t *testing.T) {
 	cltest.Expect(t, testClosure, "x: Hello, world!\n")
 }
 
+var testMethodClosure = `
+	import "fmt"
+
+	type M struct {
+		Sym string
+	}
+	
+	func (m *M) Test(prompt string) (n int, err error) {
+		n, err = fmt.Println(prompt + m.Sym + x)
+		return
+	}
+	
+	func (m *M) Test2(int) {
+		fmt.Println(m.Sym)
+	}
+	
+	m := &M{"#"}
+	foo := m.Test
+	foo2 := m.Test2
+
+	x := "Hello, world!"
+	foo("x: ")
+	foo2(0)
+`
+
+func TestMethodClosure(t *testing.T) {
+	cltest.Expect(t, testMethodClosure, "x: #Hello, world!\n#\n")
+}
+
 // -----------------------------------------------------------------------------
 
 var testClosurev = `

--- a/exec/golang/func.go
+++ b/exec/golang/func.go
@@ -192,10 +192,14 @@ func (p *Builder) CallFunc(fun *FuncInfo, nexpr int) *Builder {
 // CallFuncv instr
 func (p *Builder) CallFuncv(fun *FuncInfo, nexpr, arity int) *Builder {
 	if fun.isMethod == 1 {
-		args := p.rhs.GetArgs(arity)
+		n := arity
+		if arity < 0 {
+			n = len(fun.in) + 1
+		}
+		args := p.rhs.GetArgs(n)
 		recv := args[0]
 		args = args[1:]
-		p.rhs.Ret(arity, args...)
+		p.rhs.Ret(n, args...)
 		p.rhs.Push(fun.getFuncExpr(recv.(ast.Expr)))
 	} else {
 		p.rhs.Push(fun.getFuncExpr(nil))


### PR DESCRIPTION
fix #608, convert struct method closure to func closure

```
fn := m.Test 
// cl modify ast to closure
=> fn := func() { m.Test() }
```

Go+ code 
```
type M struct {
	Sym string
}

func (m M) Test(a string, n ...int) int {
	println(m.Sym,a,n)
	return 0
}

m1 := &M{"#"}
fn := m1.Test
fn("word",100,200)
```
generate Golang code
```
package main

import fmt "fmt"

type M struct {
	Sym string
}

var (
	m1 *M
	fn func(string, ...int) int
)

func main() { 
//line ./main.gop:11
	m1 = &M{Sym: "#"}
//line ./main.gop:12
	fn = func(_arg_0 string, _arg_1 ...int) (_ret_1 int) { 
//line ./main.gop:12
		return (*m1).Test(_arg_0, _arg_1...)
	}
//line ./main.gop:13
	fn("word", 100, 200)
}
func (recv M) Test(_arg_0 string, _arg_1 ...int) (_ret_1 int) { 
//line ./main.gop:7
	fmt.Println(recv.Sym, _arg_0, _arg_1)
//line ./main.gop:8
	return 0
}
```