### PR TITLE
cl, bytecode: support close goinstr

### DIFF
--- a/ast/spec/lang_spec.go
+++ b/ast/spec/lang_spec.go
@@ -52,4 +52,24 @@ func IsConstBound(kind ConstKind) bool {
 	return kind <= BigFloat
 }
 
+func KindName(kind ConstKind) string {
+	switch kind {
+	case BigInt:
+		return "bigint"
+	case BigRat:
+		return "bigrat"
+	case BigFloat:
+		return "bigfloat"
+	case ConstUnboundInt:
+		return "unbound int"
+	case ConstUnboundFloat:
+		return "unbound float"
+	case ConstUnboundComplex:
+		return "unbound complex"
+	case ConstUnboundPtr:
+		return "unbound ptr"
+	}
+	return kind.String()
+}
+
 // -----------------------------------------------------------------------------

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -385,9 +385,6 @@ func igoImag(ctx *blockCtx, v *ast.CallExpr, ct callType) func() {
 
 // func close(c chan<- Type)
 func igoClose(ctx *blockCtx, v *ast.CallExpr, ct callType) func() {
-	if ct != callExpr {
-		log.Panicf("%s discards result of %s\n", gCallTypes[ct], ctx.code(v))
-	}
 	if n := len(v.Args); n != 1 {
 		if n == 0 {
 			log.Panicf("missing argument to close: %v", ctx.code(v))
@@ -400,16 +397,18 @@ func igoClose(ctx *blockCtx, v *ast.CallExpr, ct callType) func() {
 	in := ctx.infer.Pop().(iValue)
 	kind := in.Kind()
 	if kind != reflect.Chan {
-		log.Fatalf("invalid operation: close(%v) (non-chan type %v)", ctx.code(arg), spec.KindName(kind))
+		log.Panicf("invalid operation: close(%v) (non-chan type %v)", ctx.code(arg), spec.KindName(kind))
 	}
 	typ := in.Type()
 	if typ.ChanDir() == reflect.RecvDir {
-		log.Fatalf("invalid operation: close(%v) (cannot close receive-only channel)", ctx.code(arg))
+		log.Panicf("invalid operation: close(%v) (cannot close receive-only channel)", ctx.code(arg))
 	}
-	ctx.infer.Push(&nonValue{})
+	if ct == callExpr {
+		ctx.infer.Push(&nonValue{})
+	}
 	return func() {
 		expr()
-		ctx.out.GoBuiltin(typ, exec.GobClose)
+		builder(ctx, ct).GoBuiltin(typ, exec.GobClose)
 	}
 }
 

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1749,31 +1749,35 @@ var testChannelClauses = map[string]testData{
 	println(d)`, "3\n", false},
 }
 
+func TestSendStmt(t *testing.T) {
+	testScripts(t, "TestSendStmt", testChannelClauses)
+}
+
 var testCloseClauses = map[string]testData{
 	"close_channel": {`
 	c := make(chan int, 10)
 	close(c)
 	d := <-c
 	println(d)`, "0\n", false},
+	"go_close_channel": {`
+	c := make(chan int, 10)
+	go close(c)
+	printf("%v\n",<-c)`, "0\n", false},
 	"defer_close_channel": {`
 	c := make(chan int, 10)
 	defer close(c)
 	a := 10
-	printf("%T\n",a)`, "chan int\n", false},
-	"bad close non-chan": {`
+	printf("%T\n",a)`, "int\n", false},
+	"bad_close_non-chan": {`
 	close(0)`, "", true},
-	"bad close receive-only": {`
+	"bad_close_receive-only": {`
 	c := make(<-chan int)
 	close(c)`, "", true},
-	"bad close too arguments": {`
+	"bad_close_too_arguments": {`
 	c := make(chan int)
 	close(c,10)`, "", true},
-	"bad close missing argument": {`
+	"bad_close_missing_argument": {`
 	close()`, "", true},
-}
-
-func TestSendStmt(t *testing.T) {
-	testScripts(t, "TestSendStmt", testChannelClauses)
 }
 
 func TestCloseStmt(t *testing.T) {

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1746,10 +1746,36 @@ var testChannelClauses = map[string]testData{
 	c := make(chan int, 10)
 	c <- 3
 	d := <-c
-	println(d)	
-					`, "3\n", false},
+	println(d)`, "3\n", false},
+}
+
+var testCloseClauses = map[string]testData{
+	"close_channel": {`
+	c := make(chan int, 10)
+	close(c)
+	d := <-c
+	println(d)`, "0\n", false},
+	"defer_close_channel": {`
+	c := make(chan int, 10)
+	defer close(c)
+	a := 10
+	printf("%T\n",a)`, "chan int\n", false},
+	"bad close non-chan": {`
+	close(0)`, "", true},
+	"bad close receive-only": {`
+	c := make(<-chan int)
+	close(c)`, "", true},
+	"bad close too arguments": {`
+	c := make(chan int)
+	close(c,10)`, "", true},
+	"bad close missing argument": {`
+	close()`, "", true},
 }
 
 func TestSendStmt(t *testing.T) {
 	testScripts(t, "TestSendStmt", testChannelClauses)
+}
+
+func TestCloseStmt(t *testing.T) {
+	testScripts(t, "TestCloseStmt", testCloseClauses)
 }

--- a/exec/bytecode/chan.go
+++ b/exec/bytecode/chan.go
@@ -26,8 +26,6 @@ func execSend(i Instr, ctx *Context) {
 func execRecv(i Instr, p *Context) {
 	n := len(p.data)
 	v := reflect.ValueOf(p.data[n-1])
-	x, ok := v.Recv()
-	if ok {
-		p.Ret(1, x.Interface())
-	}
+	x, _ := v.Recv()
+	p.Ret(1, x.Interface())
 }

--- a/exec/bytecode/chan_test.go
+++ b/exec/bytecode/chan_test.go
@@ -53,3 +53,36 @@ func TestChan(t *testing.T) {
 		"3\n",
 	)
 }
+
+func TestChanClose(t *testing.T) {
+	println, ok := I.FindFuncv("Println")
+	if !ok {
+		t.Fatal("FindFuncv failed: Println")
+	}
+
+	b := newBuilder()
+	typ := reflect.ChanOf(3, reflect.TypeOf(0))
+	v := NewVar(typ, "p")
+	i := NewVar(reflect.TypeOf(0), "i")
+	expect(t,
+		func() {
+			b.DefineVar(v)
+			b.DefineVar(i)
+			b.Push(10)
+			b.Make(typ, 1)
+			b.StoreVar(v)
+			b.LoadVar(v)
+			b.GoBuiltin(typ, GobClose)
+			b.LoadVar(v)
+			b.Recv()
+			b.StoreVar(i)
+			b.LoadVar(i)
+			b.CallGoFuncv(println, 1, 1)
+			code := b.Resolve()
+			code.(*Code).Dump(os.Stderr)
+			ctx := NewContext(code)
+			ctx.Exec(0, code.Len())
+		},
+		"0\n",
+	)
+}

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -158,6 +158,9 @@ func execGoBuiltin(i Instr, p *Context) {
 		} else {
 			p.data[n-1] = real(p.data[n-1].(complex128))
 		}
+	case GobClose:
+		v := reflect.ValueOf(p.Pop())
+		v.Close()
 	default:
 		log.Panicln("execGoBuiltin: todo -", op)
 	}


### PR DESCRIPTION
Go+ code
```
c := make(chan int)
go close(c)
i := <- c
println(i) //output 0
```
generate Golang code
```
package main

import fmt "fmt"

var (
	c chan int
	i int
)

func main() { 
//line ./main.gop:2
	c = make(chan int)
//line ./main.gop:3
	go close(c)
//line ./main.gop:4
	i = <-c
//line ./main.gop:5
	fmt.Println(i)
}
```