### PR TITLE
support cmd gop install and gop build

### DIFF
--- a/cmd/gop/main.go
+++ b/cmd/gop/main.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 
 	"github.com/goplus/gop/cmd/internal/base"
+	"github.com/goplus/gop/cmd/internal/build"
 	"github.com/goplus/gop/cmd/internal/export"
 	"github.com/goplus/gop/cmd/internal/gengo"
 	"github.com/goplus/gop/cmd/internal/gopfmt"
 	"github.com/goplus/gop/cmd/internal/help"
+	"github.com/goplus/gop/cmd/internal/install"
 	"github.com/goplus/gop/cmd/internal/repl"
 	"github.com/goplus/gop/cmd/internal/run"
 
@@ -30,6 +32,8 @@ func init() {
 		gopfmt.Cmd,
 		export.Cmd,
 		repl.Cmd,
+		install.Cmd,
+		build.Cmd,
 	}
 }
 

--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -14,7 +14,7 @@
  limitations under the License.
 */
 
-// Package gengo implements the ``gop build'' command.
+// Package build implements the ``gop build'' command.
 package build
 
 import (

--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -1,0 +1,87 @@
+/*
+ Copyright 2020 The GoPlus Authors (goplus.org)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package gengo implements the ``gop build'' command.
+package build
+
+import (
+	"os"
+
+	"github.com/goplus/gop/cl"
+	"github.com/goplus/gop/cmd/internal/base"
+	"github.com/goplus/gop/cmd/internal/work"
+	"github.com/goplus/gop/exec/bytecode"
+	"github.com/qiniu/x/log"
+)
+
+var (
+	exitCode = 0
+)
+
+// -----------------------------------------------------------------------------
+
+// Cmd - gop go
+var Cmd = &base.Command{
+	UsageLine: "gop build [-v] <gopSrcDir>",
+	Short:     "Build for all go+ files and execute go build command",
+}
+
+var (
+	buildOutput string
+	flag        = &Cmd.Flag
+)
+
+func init() {
+	flag.StringVar(&buildOutput, "o", "", "write result to (source) file instead of stdout")
+	Cmd.Run = runCmd
+}
+
+func runCmd(cmd *base.Command, args []string) {
+	flag.Parse(args)
+	if flag.NArg() < 1 {
+		cmd.Usage(os.Stderr)
+		return
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Fail to build: %v", err)
+	}
+
+	cl.CallBuiltinOp = bytecode.CallBuiltinOp
+	log.SetFlags(log.Ldefault &^ log.LstdFlags)
+
+	err = runBuild(args, dir, buildOutput)
+	if err != nil {
+		exitCode = -1
+	}
+	os.Exit(exitCode)
+}
+
+// -----------------------------------------------------------------------------
+
+func runBuild(args []string, wd, output string) error {
+	gopBuild, err := work.NewBuild("", args, wd, output)
+	if err != nil {
+		log.Fatalf("Fail to install: %v", err)
+		return err
+	}
+
+	err = gopBuild.Build()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/internal/install/install.go
+++ b/cmd/internal/install/install.go
@@ -1,0 +1,82 @@
+/*
+ Copyright 2020 The GoPlus Authors (goplus.org)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package gengo implements the ``gop install'' command.
+package install
+
+import (
+	"os"
+
+	"github.com/goplus/gop/cl"
+	"github.com/goplus/gop/cmd/internal/base"
+	"github.com/goplus/gop/cmd/internal/work"
+	"github.com/goplus/gop/exec/bytecode"
+	"github.com/qiniu/x/log"
+)
+
+var (
+	exitCode = 0
+)
+
+// Cmd - gop go
+var Cmd = &base.Command{
+	UsageLine: "gop install [-v] <gopSrcDir>",
+	Short:     "Install compiles and installs the packages named by the import paths.",
+}
+
+var (
+	flag = &Cmd.Flag
+)
+
+func init() {
+	Cmd.Run = runCmd
+}
+
+func runCmd(cmd *base.Command, args []string) {
+	flag.Parse(args)
+	if flag.NArg() < 1 {
+		cmd.Usage(os.Stderr)
+		return
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Fail to build: %v", err)
+	}
+
+	cl.CallBuiltinOp = bytecode.CallBuiltinOp
+	log.SetFlags(log.Ldefault &^ log.LstdFlags)
+	err = runInstall(args, dir)
+	if err != nil {
+		exitCode = -1
+	}
+	os.Exit(exitCode)
+}
+
+// -----------------------------------------------------------------------------
+
+func runInstall(args []string, wd string) error {
+	gopInstall, err := work.NewInstall("", args, wd)
+	if err != nil {
+		log.Fatalf("Fail to install: %v", err)
+		return err
+	}
+
+	err = gopInstall.Install()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/internal/install/install.go
+++ b/cmd/internal/install/install.go
@@ -14,7 +14,7 @@
  limitations under the License.
 */
 
-// Package gengo implements the ``gop install'' command.
+// Package install implements the ``gop install'' command.
 package install
 
 import (

--- a/cmd/internal/work/build.go
+++ b/cmd/internal/work/build.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// NewBuild creates a Build struct which can build from goc temporary directory,
+// NewBuild creates a Build struct which can build from gop temporary directory,
 // and generate binary in current working directory
 func NewBuild(buildflags string, args []string, workingDir string, outputDir string) (*Build, error) {
 	b := &Build{

--- a/cmd/internal/work/build.go
+++ b/cmd/internal/work/build.go
@@ -1,3 +1,18 @@
+/*
+ Copyright 2020 The GoPlus Authors (goplus.org)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 package work
 
 import (

--- a/cmd/internal/work/build.go
+++ b/cmd/internal/work/build.go
@@ -1,0 +1,73 @@
+package work
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// NewBuild creates a Build struct which can build from goc temporary directory,
+// and generate binary in current working directory
+func NewBuild(buildflags string, args []string, workingDir string, outputDir string) (*Build, error) {
+	b := &Build{
+		BuildFlags: buildflags,
+		WorkingDir: workingDir,
+	}
+	if err := b.CreateTmpWorkingDir(); err != nil {
+		return nil, err
+	}
+	b.OriGOPATH = os.Getenv("GOPATH")
+	if b.OriGOPATH == "" {
+		b.NewGOPATH = b.TmpDir
+	} else {
+		b.NewGOPATH = fmt.Sprintf("%v:%v", b.TmpDir, b.OriGOPATH)
+	}
+	var packages []string
+	for _, arg := range args {
+		dir, _ := filepath.Split(arg)
+		fset := token.NewFileSet()
+		pkgs, _ := parser.ParseDir(fset, dir, nil, 0)
+		if _, ok := pkgs["main"]; ok {
+			b.Target = filepath.Join(b.WorkingDir, dir)
+		}
+		packages = append(packages, filepath.Join(dir, "gop_autogen.go"))
+		err := GenGo(dir, filepath.Join(b.TmpWorkingDir, arg))
+		if err != nil {
+			return nil, err
+		}
+	}
+	b.Packages = strings.Join(packages, " ")
+	return b, nil
+}
+
+// Build calls 'go build' tool to do building
+func (b *Build) Build() error {
+	log.Println("Go building in temp...")
+	// new -o will overwrite  previous ones
+	b.BuildFlags = b.BuildFlags + " -o " + b.Target
+	cmd := exec.Command("/bin/bash", "-c", "go build "+b.BuildFlags+" "+b.Packages)
+	cmd.Dir = b.TmpWorkingDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if b.NewGOPATH != "" {
+		// Change to temp GOPATH for go install command
+		cmd.Env = append(os.Environ(), fmt.Sprintf("GOPATH=%v", b.NewGOPATH))
+	}
+
+	log.Printf("go build cmd is: %v", cmd.Args)
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("fail to execute: %v, err: %w", cmd.Args, err)
+	}
+	if err = cmd.Wait(); err != nil {
+		return fmt.Errorf("fail to execute: %v, err: %w", cmd.Args, err)
+	}
+	log.Println("Go build exit successful.")
+	return nil
+}

--- a/cmd/internal/work/gengo.go
+++ b/cmd/internal/work/gengo.go
@@ -1,0 +1,109 @@
+package work
+
+import (
+	"errors"
+	"fmt"
+	"go/format"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/gop/ast"
+	"github.com/goplus/gop/cl"
+	"github.com/goplus/gop/exec/golang"
+	"github.com/goplus/gop/parser"
+)
+
+func GenGo(dir, toDir string) error {
+	if strings.HasPrefix(dir, "_") {
+		return nil
+	}
+	fis, err := ioutil.ReadDir(dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ReadDir failed:", err)
+		return err
+	}
+	var isPkg bool
+	for _, fi := range fis {
+		if fi.IsDir() {
+			pkgDir := path.Join(dir, fi.Name())
+			err = GenGo(pkgDir, toDir)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasSuffix(fi.Name(), ".gop") {
+			isPkg = true
+		}
+	}
+	if isPkg {
+		fmt.Printf("Compiling %s ...\n", dir)
+		isPkg, err = genGopkg(dir, toDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[ERROR] %v\n\n", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func saveGoFile(dir string, code *golang.Code) error {
+	err := os.MkdirAll(dir, 0777)
+	if err != nil {
+		return err
+	}
+	b, err := code.Bytes(nil)
+	if err != nil {
+		return err
+	}
+	data, err := format.Source(b)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(dir+"/gop_autogen.go", data, 0666)
+}
+
+func genGopkg(pkgDir, tmpDir string) (mainPkg bool, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			switch v := e.(type) {
+			case string:
+				err = errors.New(v)
+			case error:
+				err = v
+			default:
+				panic(e)
+			}
+		}
+	}()
+
+	fset := token.NewFileSet()
+	pkgDir, _ = filepath.Abs(pkgDir)
+	pkgs, err := parser.ParseDir(fset, pkgDir, nil, 0)
+	if err != nil {
+		return
+	}
+	if len(pkgs) != 1 {
+		return false, fmt.Errorf("too many packages (%d) in the same directory", len(pkgs))
+	}
+
+	pkg := getPkg(pkgs)
+	b := golang.NewBuilder(pkg.Name, nil, fset)
+	_, err = cl.NewPackage(b.Interface(), pkg, fset, cl.PkgActClAll)
+	if err != nil {
+		return
+	}
+	code := b.Resolve()
+	return pkg.Name == "main", saveGoFile(tmpDir, code)
+}
+
+func getPkg(pkgs map[string]*ast.Package) *ast.Package {
+	for _, pkg := range pkgs {
+		return pkg
+	}
+	return nil
+}

--- a/cmd/internal/work/gengo.go
+++ b/cmd/internal/work/gengo.go
@@ -1,3 +1,18 @@
+/*
+ Copyright 2020 The GoPlus Authors (goplus.org)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 package work
 
 import (

--- a/cmd/internal/work/install.go
+++ b/cmd/internal/work/install.go
@@ -1,0 +1,128 @@
+package work
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/gop/ast"
+)
+
+// Build is to describe the building/installing process of a gop build/install
+type Build struct {
+	Pkgs          ast.Package // Pkg list parsed from "go list -json ./..." command
+	NewGOPATH     string      // the new GOPATH
+	OriGOPATH     string      // the original GOPATH
+	WorkingDir    string      // the working directory
+	TmpDir        string      // the temporary directory to build the project
+	TmpWorkingDir string      // the working directory in the temporary directory, which is corresponding to the current directory in the project directory
+	Target        string      // the binary name that go build generate
+	// keep compatible with go commands:
+	// gop build [-o output] [-i] [build flags] [packages]
+	// gop install [-i] [build flags] [packages]
+	BuildFlags string // Build flags
+	Packages   string // Packages that needs to build
+}
+
+// NewInstall creates a Build struct which can install from goc temporary directory
+func NewInstall(buildflags string, args []string, workingDir string) (*Build, error) {
+	b := &Build{
+		BuildFlags: buildflags,
+		WorkingDir: workingDir,
+	}
+	if err := b.CreateTmpWorkingDir(); err != nil {
+		return nil, err
+	}
+	b.OriGOPATH = os.Getenv("GOPATH")
+	if b.OriGOPATH == "" {
+		b.NewGOPATH = b.TmpDir
+	} else {
+		b.NewGOPATH = fmt.Sprintf("%v:%v", b.TmpDir, b.OriGOPATH)
+	}
+	var packages []string
+	for _, arg := range args {
+		dir, _ := filepath.Split(arg)
+		packages = append(packages, filepath.Join(dir, "gop_autogen.go"))
+		err := GenGo(dir, filepath.Join(b.TmpWorkingDir, arg))
+		if err != nil {
+			return nil, err
+		}
+	}
+	b.Packages = strings.Join(packages, " ")
+
+	return b, nil
+}
+
+// CreateTmpWorkingDir moves the projects into a temporary directory
+func (b *Build) CreateTmpWorkingDir() error {
+	var err error
+	b.TmpDir = filepath.Join(os.TempDir(), tmpFolderName(b.WorkingDir))
+
+	// Create a new tmp folder
+	err = os.MkdirAll(filepath.Join(b.TmpDir, "src"), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("Fail to create the temporary build directory. The err is: %v", err)
+	}
+	log.Printf("Tmp project generated in: %v", b.TmpDir)
+	if err != nil {
+		log.Fatalln("Fail to move the project to temporary directory")
+		return err
+	}
+	_, lastdir := filepath.Split(b.WorkingDir)
+	b.TmpWorkingDir = filepath.Join(b.TmpDir, "src", lastdir)
+	return nil
+}
+
+// Install use the 'go install' tool to install packages
+func (b *Build) Install() error {
+	log.Println("Go building in temp...")
+	cmd := exec.Command("/bin/bash", "-c", "go install "+b.BuildFlags+" "+b.Packages)
+	cmd.Dir = b.TmpWorkingDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	whereToInstall, err := b.findWhereToInstall()
+	if err != nil {
+		// ignore the err
+		log.Fatalf("No place to install: %v", err)
+	}
+	// Change the temp GOBIN, to force binary install to original place
+	cmd.Env = append(os.Environ(), fmt.Sprintf("GOBIN=%v", whereToInstall))
+	if b.NewGOPATH != "" {
+		// Change to temp GOPATH for go install command
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GOPATH=%v", b.NewGOPATH))
+	}
+
+	log.Printf("go install cmd is: %v", cmd.Args)
+	err = cmd.Start()
+	if err != nil {
+		log.Fatalf("Fail to execute: %v. The error is: %v", cmd.Args, err)
+		return err
+	}
+	if err = cmd.Wait(); err != nil {
+		log.Fatalf("go install failed. The error is: %v", err)
+		return err
+	}
+	log.Printf("Go install successful. Binary installed in: %v", whereToInstall)
+	return nil
+}
+
+func (b *Build) findWhereToInstall() (string, error) {
+	if GOPBIN := os.Getenv("GOPBIN"); GOPBIN != "" {
+		return GOPBIN, nil
+	}
+	return filepath.Join(os.Getenv("HOME"), "gop", "bin"), nil
+}
+
+// tmpFolderName uses the first six characters of the input path's SHA256 checksum
+// as the suffix.
+func tmpFolderName(path string) string {
+	sum := sha256.Sum256([]byte(path))
+	h := fmt.Sprintf("%x", sum[:6])
+
+	return "goplus-build-" + h
+}

--- a/cmd/internal/work/install.go
+++ b/cmd/internal/work/install.go
@@ -1,3 +1,18 @@
+/*
+ Copyright 2020 The GoPlus Authors (goplus.org)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 package work
 
 import (


### PR DESCRIPTION
Execute the install command:
`gop install exec/golang/testdata/32.channel/chan.gop`
The generated binary file will be saved to env.GOPBIN. If there is no environment variable GOPBIN, save it to ~/gop/bin
Execute the build command:
`gop build exec/golang/testdata/32.channel/chan.gop -o <ouput>`


**Now the basic install and build are implemented（support single go file first）, but the buildflag is not implemented, and gengo also hopes to migrate to work.Gengo**
