### PR TITLE
fix #616, support make unidirectional channel type

### DIFF
--- a/ast/astutil/type.go
+++ b/ast/astutil/type.go
@@ -46,6 +46,20 @@ func toField(f reflect.StructField) *ast.Field {
 	return field
 }
 
+// ChanType instr
+func ChanType(typ reflect.Type) *ast.ChanType {
+	var dir ast.ChanDir
+	switch typ.ChanDir() {
+	case reflect.RecvDir:
+		dir = ast.RECV
+	case reflect.SendDir:
+		dir = ast.SEND
+	case reflect.BothDir:
+		dir = ast.RECV | ast.SEND
+	}
+	return &ast.ChanType{Dir: dir, Value: Ident(typ.Elem().String())}
+}
+
 // MapType instr
 func MapType(typ reflect.Type) *ast.MapType {
 	key := Type(typ.Key())
@@ -158,6 +172,7 @@ func Type(typ reflect.Type) ast.Expr {
 	case reflect.Interface:
 		return InterfaceType(typ)
 	case reflect.Chan:
+		return ChanType(typ)
 	case reflect.Struct:
 		return StructType(typ)
 	}

--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -151,7 +151,13 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 				log.Panicf("checkType: type `%v` doesn't implments interface `%v`", typVal, t)
 			}
 		} else if t != typVal {
-			log.Panicf("checkType: unexptected value type, require `%v`, but got `%v`\n", t, typVal)
+			if typVal.Kind() == reflect.Chan {
+				if !typVal.ConvertibleTo(t) {
+					log.Panicf("checkType: cannot use `%v` as type `%v` in argument to produce", typVal, t)
+				}
+			} else {
+				log.Panicf("checkType: unexptected value type, require `%v`, but got `%v`\n", t, typVal)
+			}
 		}
 	}
 }

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1753,3 +1753,70 @@ var testChannelClauses = map[string]testData{
 func TestSendStmt(t *testing.T) {
 	testScripts(t, "TestSendStmt", testChannelClauses)
 }
+
+var testChannelConvClauses = map[string]testData{
+	"channel_both_both": {`
+	func test(chan int){
+		println(3)
+	}
+	c := make(chan int, 10)
+	test(c)`, "3\n", false},
+	"channel_both_recv": {`
+	func test(<-chan int){
+		println(3)
+	}
+	c := make(chan int, 10)
+	test(c)`, "3\n", false},
+	"channel_both_send": {`
+	func test(<-chan int){
+		println(3)
+	}
+	c := make(chan int, 10)
+	test(c)`, "3\n", false},
+	"channel_bad_recv_both": {`
+	func test(chan int){
+		println(3)
+	}
+	c := make(<-chan int, 10)
+	test(c)`, "", true},
+	"channel_bad_recv_send": {`
+	func test(chan<- int){
+		println(3)
+	}
+	c := make(<-chan int, 10)
+	test(c)`, "", true},
+	"channel_bad_send_both": {`
+	func test(chan int){
+		println(3)
+	}
+	func test2(ch chan<- int) {
+		test(ch)
+	}
+	c := make(chan int, 10)
+	test2(c)`, "", true},
+	"channel_bad_send_recv": {`
+	func test(<-chan int){
+		println(3)
+	}
+	func test2(ch chan<- int) {
+		test(ch)
+	}
+	c := make(chan int, 10)
+	test2(c)`, "", true},
+	"channel_bad_type1": {`
+	func test(int){
+		println(3)
+	}
+	c := make(chan int, 10)
+	test(c)`, "", true},
+	"channel_bad_type2": {`
+	func test(chan int){
+		println(3)
+	}
+	c := make([]int,10)
+	test(c)`, "", true},
+}
+
+func TestChannelConvStmt(t *testing.T) {
+	testScripts(t, "TestSendStmt", testChannelConvClauses)
+}

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1747,7 +1747,7 @@ var testChannelClauses = map[string]testData{
 	c <- 3
 	d := <-c
 	println(d)	
-					`, "3\n", false},
+	`, "3\n", false},
 }
 
 func TestSendStmt(t *testing.T) {

--- a/exec/bytecode/goinstr_lstcompr.go
+++ b/exec/bytecode/goinstr_lstcompr.go
@@ -155,7 +155,14 @@ func execMake(i Instr, p *Context) {
 		if arity > 0 {
 			buffer = p.Get(-1).(int)
 		}
-		p.Ret(arity, reflect.MakeChan(typ, buffer).Interface())
+		var result interface{}
+		if typ.ChanDir() == reflect.BothDir {
+			result = reflect.MakeChan(typ, buffer).Interface()
+		} else {
+			tt := reflect.ChanOf(reflect.BothDir, typ.Elem())
+			result = reflect.MakeChan(tt, buffer).Convert(typ).Interface()
+		}
+		p.Ret(arity, result)
 	default:
 		panic("make: unexpected type")
 	}

--- a/exec/golang/testdata/32.channel/chan.gop
+++ b/exec/golang/testdata/32.channel/chan.gop
@@ -2,3 +2,6 @@ c := make(chan int, 10)
 c <- 3
 d := <-c
 println(d)
+
+e := make(<-chan int, 10)
+printf("%T\n", e)

--- a/exec/golang/type.go
+++ b/exec/golang/type.go
@@ -46,7 +46,16 @@ func toStructField(p *Builder, f reflect.StructField) *ast.Field {
 
 // ChanType instr
 func ChanType(p *Builder, typ reflect.Type) *ast.ChanType {
-	return &ast.ChanType{Dir: ast.SEND | ast.RECV, Value: Ident(typ.Elem().String())}
+	var dir ast.ChanDir
+	switch typ.ChanDir() {
+	case reflect.RecvDir:
+		dir = ast.RECV
+	case reflect.SendDir:
+		dir = ast.SEND
+	case reflect.BothDir:
+		dir = ast.RECV | ast.SEND
+	}
+	return &ast.ChanType{Dir: dir, Value: Ident(typ.Elem().String())}
 }
 
 // MapType instr


### PR DESCRIPTION
fix #616 use reflect#value.Convert
```
intType := reflect.TypeOf(100)
t := reflect.ChanOf(reflect.BothDir, intType)
t1 := reflect.ChanOf(reflect.RecvDir, intType)
v := reflect.MakeChan(t, 10)
v1 := v.Convert(t1)
fmt.Println(v1.Type().ChanDir()) 
```
output
```
<-chan
```