### PR TITLE
cl: compileSelectorExpr use better lookup method

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -51,6 +51,9 @@ func newPkgCtx(out exec.Builder, pkg *ast.Package, fset *token.FileSet) *pkgCtx 
 }
 
 func (p *pkgCtx) code(v ast.Node) string {
+	if expr, ok := v.(*ast.ParenExpr); ok {
+		v = expr.X
+	}
 	_, code := p.getCodeInfo(v)
 	return code
 }

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1366,7 +1366,7 @@ func compileSelectorExpr(ctx *blockCtx, v *ast.SelectorExpr, compileByCallExpr b
 			log.Panicln("compileSelectorExpr: symbol not found -", vx.t, v.Sel.Name)
 		}
 		if n > 1 {
-			log.Panicf("calling method %v with receiver %v (type %v) requires explicit dereference", v.Sel.Name, ctx.code(v.X), vx.t)
+			log.Panicf("calling method %v with receiver %v (type %v) requires explicit dereference.", v.Sel.Name, ctx.code(v.X), vx.t)
 		}
 		pkgPath := t.PkgPath()
 		pkg := ctx.FindGoPackage(pkgPath)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -833,6 +833,20 @@ func TestPkgMethod(t *testing.T) {
 	`, "int\n")
 }
 
+func TestPkgMethodBadCall(t *testing.T) {
+	cltest.Expect(t, `
+	import "bytes"
+	buf := bytes.NewBuffer([]byte("hello"))
+	println((&buf).String())
+	`, "", nil)
+	cltest.Expect(t, `
+	import "reflect"
+	v := reflect.ValueOf(100)
+	p := &v
+	println((&p).Kind())
+	`, "", nil)
+}
+
 func TestComplex(t *testing.T) {
 	cltest.Expect(t, `
 	c := complex(1,2)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -838,13 +838,13 @@ func TestPkgMethodBadCall(t *testing.T) {
 	import "bytes"
 	buf := bytes.NewBuffer([]byte("hello"))
 	println((&buf).String())
-	`, "", nil)
+	`, "", "calling method String with receiver &buf (type **bytes.Buffer) requires explicit dereference.")
 	cltest.Expect(t, `
 	import "reflect"
 	v := reflect.ValueOf(100)
 	p := &v
 	println((&p).Kind())
-	`, "", nil)
+	`, "", "calling method Kind with receiver &p (type **reflect.Value) requires explicit dereference.")
 }
 
 func TestComplex(t *testing.T) {


### PR DESCRIPTION
use findMethod toptr to build GoPackage symbol ` (struct).method or (*struct).method`
```
// t is struct or interface
func findMethod(t reflect.Type, name string) (method reflect.Method, toptr bool, found bool) {
	method, found = t.MethodByName(name)
	if !found && t.Kind() == reflect.Struct {
		t = reflect.PtrTo(t)
		toptr = true
		method, found = t.MethodByName(name)
	}
	return
}
```