### PR TITLE
fix #657 #660 #661 type convert

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1468,6 +1468,11 @@ func compileStarExpr(ctx *blockCtx, v *ast.StarExpr) func() {
 	x := ctx.infer.Get(-1)
 	switch vx := x.(type) {
 	case *nonValue:
+		switch t := vx.v.(type) {
+		case reflect.Type:
+			ctx.infer.Ret(1, &nonValue{reflect.PtrTo(t)})
+			return nil
+		}
 	case *goValue:
 		if vx.Kind() == reflect.Ptr {
 			ctx.infer.Ret(1, &goValue{vx.t.Elem()})

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1302,6 +1302,10 @@ func compileSelectorExpr(ctx *blockCtx, call *ast.CallExpr, v *ast.SelectorExpr,
 					pushConstVal(ctx.out, ret)
 				}
 			}
+			if t, ok := nv.FindType(name); ok {
+				ctx.infer.Ret(1, &nonValue{t})
+				return nil
+			}
 			addr, kind, ok := nv.Find(name)
 			if !ok {
 				log.Panicln("compileSelectorExpr: not found -", nv.PkgPath(), name)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -400,6 +400,15 @@ func TestTypeCast(t *testing.T) {
 	`).Equal([]byte("hello"))
 }
 
+func TestPkgTypeConv(t *testing.T) {
+	cltest.Expect(t, `
+	import "sort"
+	ar := [1,5,3,2]
+	sort.IntSlice(ar).Sort()
+	println(ar)
+	`, "[1 2 3 5]\n")
+}
+
 func TestAppendErr(t *testing.T) {
 	cltest.Expect(t, `
 		append()

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -409,6 +409,16 @@ func TestPkgTypeConv(t *testing.T) {
 	`, "[1 2 3 5]\n")
 }
 
+func TestRuneType(t *testing.T) {
+	cltest.Expect(t, `
+	a := 'a'
+	printf("%T\n",a)
+	`, "int32\n")
+	cltest.Expect(t, `
+	printf("%T\n",'a')
+	`, "int32\n")
+}
+
 func TestAppendErr(t *testing.T) {
 	cltest.Expect(t, `
 		append()

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1747,6 +1747,10 @@ var testStarExprClauses = map[string]testData{
 					println(a1, *c.b, *c.m["foo"], *c.s[0])
 	
 						`, "3 3 8 11\n", false},
+	"start expr ptr conv": {`
+					a := 10
+					println(*(*int)(&a))
+					`, "10\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/value.go
+++ b/cl/value.go
@@ -305,6 +305,9 @@ func (p *constVal) bound(t reflect.Type, b exec.Builder) {
 		}
 		return
 	}
+	if kind == reflect.Interface && astutil.IsConstBound(p.kind) {
+		t = exec.TypeFromKind(p.kind)
+	}
 	v := boundConst(p.v, t)
 	p.v, p.kind = v, kind
 	p.reserve.Push(b, v)


### PR DESCRIPTION
fix #657
fix #660
fix #661

Go+ code
```
import(
	"sort"
)
// #657
ar := [1,5,3,2]
sort.IntSlice(ar).Sort()
println(ar)

// #660
i := 100
println(*(*int)(&i))

// #661
printf("%T\n",'a')
```
generate Golang code
```
package main

import (
	fmt "fmt"
	sort "sort"
)

var (
	ar []int
	i  int
)

func main() { 
//line ./main.gop:6
	ar = []int{1, 5, 3, 2}
//line ./main.gop:7
	(sort.IntSlice).Sort(sort.IntSlice(ar))
//line ./main.gop:8
	fmt.Println(ar)
//line ./main.gop:11
	i = 100
//line ./main.gop:12
	fmt.Println(*(*int)(&i))
//line ./main.gop:15
	fmt.Printf("%T\n", int32(97))
}
```