### PR TITLE
fix #662, bytecode context record func args

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -590,7 +590,7 @@ func compileUnaryExpr(ctx *blockCtx, v *ast.UnaryExpr) func() {
 		}
 		if v.Op == token.AND {
 			vx := x.(iValue)
-			t := reflect.TypeOf(reflect.New(vx.Type()).Interface())
+			t := reflect.PtrTo(vx.Type())
 			ret := &goValue{t: t}
 			ctx.infer.Ret(1, ret)
 			return func() {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -413,6 +413,32 @@ func TestTakeAddrInFunc(t *testing.T) {
 	test1(m)
 	test2(m)
 	`, "100 1\n1 100\n")
+	cltest.Expect(t, `
+	type M struct {
+		X int
+		Y int
+	}
+	func set(s *string, m M) int {
+		*s = "s0"
+		return 100
+	}
+	func set2(s *string, m *M) int {
+		*s = "s3"
+		m.Y = -2
+		return 200
+	}
+	func f2(s string, s2 string, m M) {
+		func() {
+			println("hello",set(&s,m))
+			m.X = -1
+			println(s, s2, m)
+		}()
+		set2(&s2,&m)
+		println(s, s2, m)
+	}
+	m := M{1, 2}
+	f2("s1", "s2", m)
+	`, "hello 100\ns0 s2 {-1 2}\ns0 s3 {-1 -2}\n")
 }
 
 func TestTakeAddrMap(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -366,6 +366,13 @@ func TestPanic(t *testing.T) {
 	)
 }
 
+func TestBadPkgPath(t *testing.T) {
+	cltest.Expect(t, `
+	import "badpath"
+	println(badpath.Version())
+	`, "", nil)
+}
+
 func TestTakeAddrInFunc(t *testing.T) {
 	cltest.Expect(t, `
 	func test(i int) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -366,6 +366,55 @@ func TestPanic(t *testing.T) {
 	)
 }
 
+func TestTakeAddrInFunc(t *testing.T) {
+	cltest.Expect(t, `
+	func test(i int) {
+		printf("%T %T\n",i,&i)
+	}
+	test(100)
+	`, "int *int\n")
+	cltest.Expect(t, `
+	func test(i *int, j int) {
+		*i = 100
+		j = 100
+	}
+	var m1,m2 int
+	test(&m1,m2)
+	println(m1,m2)
+	`, "100 0\n")
+	cltest.Expect(t, `
+	func test(i []int) []int {
+		i = append(i,100)
+		println(i)
+		return i
+	}
+	i := [1,2,3]
+	j := test(i)
+	println(i)
+	println(j)
+	`, "[1 2 3 100]\n[1 2 3]\n[1 2 3 100]\n")
+	cltest.Expect(t, `
+	type M struct {
+		X int
+		Y int
+	}
+	func setx(i *M) {
+		i.X = 100
+	}
+	func test1(i M) {
+		setx(&i)
+		printf("%v %v\n",i.X,i.Y)
+	}
+	func test2(i M) {
+		i.Y = 100
+		printf("%v %v\n",i.X,i.Y)
+	}
+	m := M{1,1}
+	test1(m)
+	test2(m)
+	`, "100 1\n1 100\n")
+}
+
 func TestTakeAddrMap(t *testing.T) {
 	cltest.Expect(t, `
 		m := {1:"hello",2:"ok"}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -394,6 +394,17 @@ func TestTakeAddrInFunc(t *testing.T) {
 	println(j)
 	`, "[1 2 3 100]\n[1 2 3]\n[1 2 3 100]\n")
 	cltest.Expect(t, `
+	import "fmt"
+	func set(e *error) {
+		*e = fmt.Errorf("error")
+	}
+	func fn(err error) {
+		fmt.Println(err)
+		set(&err)
+		fmt.Println(err)
+	}
+	fn(nil)`, "<nil>\nerror\n")
+	cltest.Expect(t, `
 	type M struct {
 		X int
 		Y int

--- a/exec/bytecode/context.go
+++ b/exec/bytecode/context.go
@@ -101,7 +101,7 @@ func (ctx *Context) switchScope(parent *varScope, vmgr *varManager) (old savedSc
 	ctx.addrs = make([]reflect.Value, size)
 	for i := size; i > 0; i-- {
 		v := reflect.ValueOf(ctx.Get(-i))
-		if v.Kind() == reflect.Struct {
+		if v.Kind() != reflect.Ptr && v.IsValid() {
 			nv := reflect.New(v.Type()).Elem()
 			nv.Set(v)
 			ctx.addrs[size-i] = nv

--- a/exec/bytecode/context.go
+++ b/exec/bytecode/context.go
@@ -89,7 +89,7 @@ type savedScopeCtx struct {
 	varScope
 }
 
-func (ctx *Context) switchScope(parent *varScope, vmgr *varManager) (old savedScopeCtx) {
+func (ctx *Context) switchScope(parent *varScope, vmgr *varManager, ins []reflect.Type) (old savedScopeCtx) {
 	old.base = ctx.base
 	old.ip = ctx.ip
 	old.varScope = ctx.varScope
@@ -99,14 +99,16 @@ func (ctx *Context) switchScope(parent *varScope, vmgr *varManager) (old savedSc
 
 	size := ctx.Len()
 	ctx.addrs = make([]reflect.Value, size)
-	for i := size; i > 0; i-- {
+	for i := len(ins); i > 0; i-- {
 		v := reflect.ValueOf(ctx.Get(-i))
-		if v.Kind() != reflect.Ptr && v.IsValid() {
-			nv := reflect.New(v.Type()).Elem()
-			nv.Set(v)
-			ctx.addrs[size-i] = nv
-		} else {
+		if v.Kind() == reflect.Ptr {
 			ctx.addrs[size-i] = v
+		} else {
+			nv := reflect.New(ins[len(ins)-i]).Elem()
+			if v.IsValid() {
+				nv.Set(v)
+			}
+			ctx.addrs[size-i] = nv
 		}
 	}
 	return

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -36,7 +36,7 @@ func execLoad(i Instr, p *Context) {
 func execAddr(i Instr, p *Context) {
 	idx := int32(i) << bitsOp >> bitsOp
 	index := (p.base + int(idx))
-	if p.addrs[index].Kind() == reflect.Struct {
+	if p.addrs[index].Kind() != reflect.Ptr {
 		p.Push(p.addrs[index].Addr().Interface())
 	} else {
 		p.Push(p.data[index])

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -317,7 +317,7 @@ func (p *FuncInfo) execFunc(ctx *Context) {
 }
 
 func (p *FuncInfo) exec(ctx *Context, parent *varScope) {
-	old := ctx.switchScope(parent, &p.varManager)
+	old := ctx.switchScope(parent, &p.varManager, p.in)
 	p.execFunc(ctx)
 	if ctx.ip != ipReturnN {
 		ctx.data = ctx.data[:ctx.base-len(p.in)]

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -26,31 +26,23 @@ import (
 func execLoad(i Instr, p *Context) {
 	idx := int32(i) << bitsOp >> bitsOp
 	index := p.base + int(idx)
-	if p.addrs[index].Kind() == reflect.Struct {
-		p.Push(p.addrs[index].Interface())
-	} else {
-		p.Push(p.data[index])
-	}
+	p.Push(p.args[index].Interface())
 }
 
 func execAddr(i Instr, p *Context) {
 	idx := int32(i) << bitsOp >> bitsOp
 	index := (p.base + int(idx))
-	if p.addrs[index].Kind() != reflect.Ptr {
-		p.Push(p.addrs[index].Addr().Interface())
+	if p.args[index].Kind() != reflect.Ptr {
+		p.Push(p.args[index].Addr().Interface())
 	} else {
-		p.Push(p.data[index])
+		p.Push(p.args[index].Interface())
 	}
 }
 
 func execStore(i Instr, p *Context) {
 	idx := int32(i) << bitsOp >> bitsOp
 	index := p.base + int(idx)
-	if p.addrs[index].Kind() == reflect.Struct {
-		p.addrs[index].Set(reflect.ValueOf(p.Pop()))
-	} else {
-		p.data[index] = p.Pop()
-	}
+	p.args[index].Set(reflect.ValueOf(p.Pop()))
 }
 
 const (

--- a/exec/bytecode/goinstr_lstcompr.go
+++ b/exec/bytecode/goinstr_lstcompr.go
@@ -60,7 +60,7 @@ func (c *ForPhrase) exec(ctx *Context) {
 		}
 		if blockScope { // TODO: move out of `for` statement
 			parent := ctx.varScope
-			old = ctx.switchScope(&parent, &c.block.varManager)
+			old = ctx.switchScope(&parent, &c.block.varManager, nil)
 		}
 		if ipCond > 0 {
 			ctx.Exec(ip, ipCond)

--- a/exec/bytecode/var_test.go
+++ b/exec/bytecode/var_test.go
@@ -81,10 +81,10 @@ func TestParentCtx(t *testing.T) {
 	ctx.SetVar(z, "78")
 
 	p0 := ctx.getScope(true)
-	old := ctx.switchScope(p0, newVarManager())
+	old := ctx.switchScope(p0, newVarManager(), nil)
 
 	p1 := ctx.getScope(true)
-	ctx.switchScope(p1, newVarManager(x, y))
+	ctx.switchScope(p1, newVarManager(x, y), nil)
 
 	ctx.Exec(0, code.Len())
 	ctx.restoreScope(old)
@@ -123,10 +123,10 @@ func TestAddrVar(t *testing.T) {
 	ctx.SetVar(z, "78")
 
 	p0 := ctx.getScope(true)
-	old := ctx.switchScope(p0, newVarManager())
+	old := ctx.switchScope(p0, newVarManager(), nil)
 
 	p1 := ctx.getScope(true)
-	ctx.switchScope(p1, newVarManager(x, y))
+	ctx.switchScope(p1, newVarManager(x, y), nil)
 
 	ctx.Exec(0, code.Len())
 	ctx.restoreScope(old)

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -148,7 +148,7 @@ func (p *Builder) Load(idx int32) *Builder {
 
 // Addr instr
 func (p *Builder) Addr(idx int32) *Builder {
-	p.rhs.Push(p.argIdent(idx))
+	p.rhs.Push(&ast.UnaryExpr{Op: token.AND, X: p.argIdent(idx)})
 	return p
 }
 


### PR DESCRIPTION
fix #662

**Not ready**

bytecode: ctx recored func args for execLoad/Save/Store
golang: fix Addr instr  for func. 

Go+ code
```
func set(v *interface{}) {
	*v = 100
}
func test(v interface{}) {
	printf("%v %T\n",v,v)
	set(&v)
	printf("%v %T\n",v,v)
}
test(nil)
```
---- output -----
```
<nil> <nil>
100 int
```

generate Golang code
```
package main

import fmt "fmt"

func main() { 
//line ./main.gop:10
	test(nil)
}
func test(_arg_0 interface {
}) { 
//line ./main.gop:6
	fmt.Printf("%v %T\n", _arg_0, _arg_0)
//line ./main.gop:7
	set(&_arg_0)
//line ./main.gop:8
	fmt.Printf("%v %T\n", _arg_0, _arg_0)
}
func set(_arg_0 *interface {
}) { 
//line ./main.gop:3
	*_arg_0 = 100
}
```