### PR TITLE
fix #666: import anytime for REPL

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -153,6 +153,10 @@ const (
 
 // NewPackage creates a Go+ package instance.
 func NewPackage(out exec.Builder, pkg *ast.Package, fset *token.FileSet, act PkgAct) (p *Package, err error) {
+	return NewPackageEx(out, pkg, fset, act, nil)
+}
+
+func NewPackageEx(out exec.Builder, pkg *ast.Package, fset *token.FileSet, act PkgAct, imports map[string]string) (p *Package, err error) {
 	if pkg == nil {
 		return nil, ErrNotFound
 	}
@@ -163,7 +167,7 @@ func NewPackage(out exec.Builder, pkg *ast.Package, fset *token.FileSet, act Pkg
 	ctxPkg := newPkgCtx(out, pkg, fset)
 	ctx := newGblBlockCtx(ctxPkg)
 	for _, f := range pkg.Files {
-		loadFile(ctx, f)
+		loadFile(ctx, f, imports)
 	}
 	switch act {
 	case PkgActClAll:
@@ -234,11 +238,13 @@ func (p *Package) Find(name string) (kind SymKind, v interface{}, ok bool) {
 	return
 }
 
-func loadFile(ctx *blockCtx, f *ast.File) {
+func loadFile(ctx *blockCtx, f *ast.File, imports map[string]string) {
 	file := newFileCtx(ctx)
 	last := len(f.Decls) - 1
 	ctx.file = file
-
+	for name, pkg := range imports {
+		ctx.file.imports[name] = pkg
+	}
 	for i, decl := range f.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -294,3 +294,30 @@ func TestStruct(t *testing.T) {
 		t.Fatal("n:", v)
 	}
 }
+
+func TestImports(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.Parse(fset, "", `fmt.Println("hello")`, 0)
+	if err != nil || len(pkgs) != 1 {
+		t.Fatal("ParseFSDir failed:", err, len(pkgs))
+	}
+
+	bar := pkgs["main"]
+	b := exec.NewBuilder(nil)
+	imports := make(map[string]string)
+	imports["fmt"] = "fmt"
+	_, err = NewPackageEx(b.Interface(), bar, fset, PkgActClMain, imports)
+	if err != nil {
+		t.Fatal("Compile failed:", err)
+	}
+	code := b.Resolve()
+
+	ctx := exec.NewContext(code)
+	ctx.Exec(0, code.Len())
+	if v := ctx.Get(-1); v != nil {
+		t.Fatal("error:", v)
+	}
+	if v := ctx.Get(-2); v != int(6) {
+		t.Fatal("n:", v)
+	}
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -19,6 +19,7 @@ package repl
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/goplus/gop/cl"
@@ -41,6 +42,7 @@ type REPL struct {
 	ip           int          // store the ip after exec
 	continueMode bool         // switch to control the promot type
 	term         UI           // liner instance
+	imports      map[string]string
 }
 
 const (
@@ -52,7 +54,7 @@ const (
 
 // New creates a REPL object.
 func New() *REPL {
-	return &REPL{}
+	return &REPL{imports: make(map[string]string)}
 }
 
 // SetUI initializes UI.
@@ -82,8 +84,34 @@ func (r *REPL) continueModeByLine(line string) {
 	r.term.SetPrompt(NormalPrompt)
 }
 
+func parserImport(line string) (name string, path string, err error) {
+	// import ioutil "io/ioutil"
+	if pos := strings.Index(line, " "); pos > 0 {
+		name = line[:pos]
+		path, err = strconv.Unquote(line[pos+1:])
+	} else {
+		path, err = strconv.Unquote(line)
+		name = path
+		if pos := strings.Index(path, "/"); pos > 0 {
+			name = path[:pos]
+		}
+	}
+	return
+}
+
 // run execute the input line
 func (r *REPL) run(newLine string) (err error) {
+	if strings.HasPrefix(newLine, "import ") {
+		line := strings.TrimSpace(newLine[7:])
+		if len(line) > 2 && line[len(line)-1] == '"' {
+			name, path, err := parserImport(line)
+			if err != nil {
+				return err
+			}
+			r.imports[name] = path
+			return nil
+		}
+	}
 	src := r.src + newLine + "\n"
 	defer func() {
 		if errR := recover(); errR != nil {
@@ -114,7 +142,7 @@ func (r *REPL) run(newLine string) (err error) {
 
 	b := exec.NewBuilder(nil)
 
-	_, err = cl.NewPackage(b.Interface(), pkgs["main"], fset, cl.PkgActClMain)
+	_, err = cl.NewPackageEx(b.Interface(), pkgs["main"], fset, cl.PkgActClMain, r.imports)
 	if err != nil {
 		if err == cl.ErrMainFuncNotFound {
 			err = nil

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -92,8 +92,8 @@ func parserImport(line string) (name string, path string, err error) {
 	} else {
 		path, err = strconv.Unquote(line)
 		name = path
-		if pos := strings.Index(path, "/"); pos > 0 {
-			name = path[:pos]
+		if pos := strings.LastIndex(path, "/"); pos > 0 {
+			name = path[pos+1:]
 		}
 	}
 	return


### PR DESCRIPTION
fix #666

only support signal import line
```
import "path"
import name "path"
```

```
$ ./gop repl
Welcome to Go+ console!
>>> a := 10
>>> import "fmt"
>>> fmt.Println(a)
10
3,<nil>
>>> import "os"
>>> fmt.Fprintf(os.Stdout,"hello\n")
hello
6,<nil>
>>> 
```