### PR TITLE
cl: fix AddrVar check

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -194,7 +194,7 @@ func compileIdent(ctx *blockCtx, ident *ast.Ident, compileByCallExpr bool) func(
 			ctx.infer.Push(&goValue{t: typ})
 			ctx.resetFieldIndex()
 			return func() {
-				if ctx.takeAddr || (ctx.checkLoadAddr && kind != reflect.Slice && kind != reflect.Map) {
+				if ctx.takeAddr || (ctx.checkLoadAddr && kind != reflect.Slice && kind != reflect.Map && kind != reflect.Ptr) {
 					ctx.out.AddrVar(v.v)
 				} else {
 					ctx.out.LoadVar(v.v)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1457,6 +1457,24 @@ var testMethodClauses = map[string]testData{
 					m.Foo()
 					println(m)
 					`, "foo 0\n0\n", false},
+	"method typ/ptr info": {`
+					type Pt struct {
+						X int
+						Y int
+					}
+					func (p *Pt) Test() {
+						println(p)
+					}
+					func (p *Pt) Test2() {
+						println(*p)
+					}
+					pt1 := Pt{1,2}
+					pt2 := &Pt{3,4}
+					pt1.Test()
+					pt1.Test2()
+					pt2.Test()
+					pt2.Test2()
+	`, "&{1 2}\n{1 2}\n&{3 4}\n{3 4}\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1468,16 +1468,22 @@ var testMethodClauses = map[string]testData{
 					func (p *Pt) Test2() {
 						println(*p)
 					}
+					func (p Pt) Test3() {
+						println(p)
+					}
 					pt1 := Pt{1,2}
 					pt2 := &Pt{3,4}
 					pt3 := &pt2
 					pt1.Test()
 					pt1.Test2()
+					pt1.Test3()
 					pt2.Test()
 					pt2.Test2()
+					pt2.Test3()
 					(*pt3).Test()
 					(*pt3).Test2()
-	`, "&{1 2}\n{1 2}\n&{3 4}\n{3 4}\n&{3 4}\n{3 4}\n", false},
+					(*pt3).Test3()
+	`, "&{1 2}\n{1 2}\n{1 2}\n&{3 4}\n{3 4}\n{3 4}\n&{3 4}\n{3 4}\n{3 4}\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1470,11 +1470,14 @@ var testMethodClauses = map[string]testData{
 					}
 					pt1 := Pt{1,2}
 					pt2 := &Pt{3,4}
+					pt3 := &pt2
 					pt1.Test()
 					pt1.Test2()
 					pt2.Test()
 					pt2.Test2()
-	`, "&{1 2}\n{1 2}\n&{3 4}\n{3 4}\n", false},
+					(*pt3).Test()
+					(*pt3).Test2()
+	`, "&{1 2}\n{1 2}\n&{3 4}\n{3 4}\n&{3 4}\n{3 4}\n", false},
 }
 
 func TestMethodCases(t *testing.T) {

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -382,6 +382,9 @@ func (p *Builder) StoreVar(v *Var) *Builder {
 
 // AddrVar instr
 func (p *Builder) AddrVar(v *Var) *Builder {
+	if v.Type().Kind() == reflect.Ptr {
+		return p.LoadVar(v)
+	}
 	p.addrVar(makeAddr(p.nestDepth-v.nestDepth, v.idx))
 	return p
 }

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -382,9 +382,6 @@ func (p *Builder) StoreVar(v *Var) *Builder {
 
 // AddrVar instr
 func (p *Builder) AddrVar(v *Var) *Builder {
-	if v.Type().Kind() == reflect.Ptr {
-		return p.LoadVar(v)
-	}
 	p.addrVar(makeAddr(p.nestDepth-v.nestDepth, v.idx))
 	return p
 }


### PR DESCRIPTION
fix #681 cl AddrVar call check.

**if merged https://github.com/goplus/gop/pull/704 (methodof), don't merge this PR.**

Go+ code
```
type Pt struct {
	X int
	Y int
}
func (p *Pt) Test() {
	println("pt", p)
}
func (p *Pt) Test2() {
	println("pt", *p)
}

pt1 := Pt{1,2}
pt2 := &Pt{3,4}
pt3 := &pt2

pt1.Test()
pt1.Test2()
pt2.Test()
pt2.Test2()
(*pt3).Test()
(*pt3).Test2()
```
generate Golang code
```
package main

import fmt "fmt"

type Pt struct {
	X int
	Y int
}

var (
	pt1 Pt
	pt2 *Pt
	pt3 **Pt
)

func main() { 
//line ./main.gop:13
	pt1 = Pt{X: 1, Y: 2}
//line ./main.gop:14
	pt2 = &Pt{X: 3, Y: 4}
//line ./main.gop:15
	pt3 = &pt2
//line ./main.gop:17
	pt1.Test()
//line ./main.gop:18
	pt1.Test2()
//line ./main.gop:19
	pt2.Test()
//line ./main.gop:20
	pt2.Test2()
//line ./main.gop:21
	(*pt3).Test()
//line ./main.gop:22
	(*pt3).Test2()
}
func (_recv *Pt) Test2() { 
//line ./main.gop:10
	fmt.Println("pt", *_recv)
}
func (_recv *Pt) Test() { 
//line ./main.gop:7
	fmt.Println("pt", _recv)
}

```
