### PR TITLE
cl: fix start addr set & support multi indirect

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -182,15 +182,15 @@ type blockCtx struct {
 	file            *fileCtx
 	parent          *blockCtx
 	syms            map[string]iSymbol
-	noExecCtx       bool
-	takeAddr        bool
-	indirect        int
-	checkFlag       bool
-	checkLoadAddr   bool
 	fieldStructType reflect.Type
 	fieldIndex      []int
 	fieldExprX      func()
+	indirect        int
 	underscore      int
+	noExecCtx       bool
+	takeAddr        bool
+	checkFlag       bool
+	checkLoadAddr   bool
 }
 
 // function block ctx

--- a/cl/context.go
+++ b/cl/context.go
@@ -184,7 +184,7 @@ type blockCtx struct {
 	syms            map[string]iSymbol
 	noExecCtx       bool
 	takeAddr        bool
-	indirect        bool
+	indirect        int
 	checkFlag       bool
 	checkLoadAddr   bool
 	fieldStructType reflect.Type

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -183,7 +183,15 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 				ctx.out.StoreVar(v.v)
 			}
 		} else if op, ok := addrops[mode]; ok {
-			if ctx.indirect > 0 {
+			if typ.Kind() == reflect.Ptr {
+				ctx.out.LoadVar(v.v)
+				elem := addrTyp
+				for i := 0; i < ctx.indirect; i++ {
+					elem = elem.Elem()
+					ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+				}
+				ctx.out.AddrOp(kindOf(typ), op)
+			} else if ctx.indirect > 0 {
 				ctx.out.LoadVar(v.v)
 				elem := addrTyp
 				for i := 0; i < ctx.indirect-1; i++ {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -54,13 +54,17 @@ func compileExprLHS(ctx *blockCtx, expr ast.Expr, mode compileMode) {
 	case *ast.ParenExpr:
 		compileExprLHS(ctx, v.X, mode)
 	case *ast.UnaryExpr:
-		ctx.indirect = !ctx.indirect
-		compileExprLHS(ctx, v.X, mode)
+		compileUnaryExprLHS(ctx, v, mode)
 	case *ast.CallExpr:
 		compileCallExprLHS(ctx, v, mode)
 	default:
 		log.Panicln("compileExprLHS failed: unknown -", reflect.TypeOf(v))
 	}
+}
+
+func compileUnaryExprLHS(ctx *blockCtx, v *ast.UnaryExpr, mode token.Token) {
+	ctx.indirect = !ctx.indirect
+	compileExprLHS(ctx, v.X, mode)
 }
 
 func compileCallExprLHS(ctx *blockCtx, v *ast.CallExpr, mode token.Token) {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -195,7 +195,12 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 	} else {
 		if mode == token.ASSIGN || mode == token.DEFINE {
 			if ctx.indirect > 0 {
-				ctx.out.Load(addr.(*stackVar).index).AddrOp(kindOf(addr.(*stackVar).getType()), exec.OpAssign)
+				ctx.out.Load(addr.(*stackVar).index)
+				for i := 0; i < ctx.indirect-1; i++ {
+					typ = reflect.PtrTo(typ)
+					ctx.out.AddrOp(kindOf(typ), exec.OpAddrVal)
+				}
+				ctx.out.AddrOp(kindOf(addrTyp), exec.OpAssign)
 			} else {
 				ctx.out.Store(addr.(*stackVar).index)
 			}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -183,9 +183,14 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 				ctx.out.StoreVar(v.v)
 			}
 		} else if op, ok := addrops[mode]; ok {
-			typ := v.v.Type()
-			if typ.Kind() == reflect.Ptr {
-				ctx.out.LoadVar(v.v).AddrOp(kindOf(typ), op)
+			if ctx.indirect > 0 {
+				ctx.out.LoadVar(v.v)
+				elem := addrTyp
+				for i := 0; i < ctx.indirect-1; i++ {
+					elem = elem.Elem()
+					ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+				}
+				ctx.out.AddrOp(kindOf(typ), op)
 			} else {
 				ctx.out.AddrVar(v.v).AddrOp(kindOf(typ), op)
 			}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1004,7 +1004,13 @@ func compileIndexExprLHS(ctx *blockCtx, v *ast.IndexExpr, mode compileMode) {
 			logIllTypeMapIndexPanic(ctx, v, t, typIdx)
 		}
 		if ctx.indirect > 0 {
-			ctx.out.MapIndex(false).AddrOp(kindOf(typElem), exec.OpAssign)
+			ctx.out.MapIndex(false)
+			elem := styp
+			for i := 0; i < ctx.indirect-1; i++ {
+				elem = elem.Elem()
+				ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+			}
+			ctx.out.AddrOp(kindOf(typElem), exec.OpAssign)
 		} else {
 			ctx.out.SetMapIndex()
 		}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -984,7 +984,13 @@ func compileIndexExprLHS(ctx *blockCtx, v *ast.IndexExpr, mode compileMode) {
 			}
 		}
 		if ctx.indirect > 0 {
-			ctx.out.Index(-1).AddrOp(kindOf(typElem), exec.OpAssign)
+			ctx.out.Index(-1)
+			elem := styp
+			for i := 0; i < ctx.indirect-1; i++ {
+				elem = elem.Elem()
+				ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+			}
+			ctx.out.AddrOp(kindOf(typElem), exec.OpAssign)
 		} else {
 			ctx.out.SetIndex(-1)
 		}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -156,7 +156,8 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 		}
 	}
 
-	typ := addr.getType()
+	addrTyp := addr.getType()
+	typ := addrTyp
 	for i := 0; i < ctx.indirect; i++ {
 		typ = typ.Elem()
 	}
@@ -165,7 +166,13 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 	if v, ok := addr.(*execVar); ok {
 		if mode == token.ASSIGN || mode == token.DEFINE {
 			if ctx.indirect > 0 {
-				ctx.out.LoadVar(v.v).AddrOp(kindOf(typ), exec.OpAssign)
+				ctx.out.LoadVar(v.v)
+				elem := addrTyp
+				for i := 0; i < ctx.indirect-1; i++ {
+					elem = elem.Elem()
+					ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+				}
+				ctx.out.AddrOp(kindOf(typ), exec.OpAssign)
 			} else {
 				ctx.out.StoreVar(v.v)
 			}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1217,7 +1217,7 @@ func compileSelectorExprLHS(ctx *blockCtx, v *ast.SelectorExpr, mode compileMode
 			if t.Kind() == reflect.Struct {
 				if sf, ok := t.FieldByName(name); ok {
 					typ := sf.Type
-					if ctx.indirect > 0 {
+					for i := 0; i < ctx.indirect; i++ {
 						typ = typ.Elem()
 					}
 					checkType(typ, in, ctx.out)
@@ -1234,7 +1234,13 @@ func compileSelectorExprLHS(ctx *blockCtx, v *ast.SelectorExpr, mode compileMode
 					}
 					ctx.checkLoadAddr = false
 					if ctx.indirect > 0 {
-						ctx.out.LoadField(fieldStructType, fieldIndex).AddrOp(kindOf(typ), exec.OpAssign)
+						ctx.out.LoadField(fieldStructType, fieldIndex)
+						elem := sf.Type
+						for i := 0; i < ctx.indirect-1; i++ {
+							elem = elem.Elem()
+							ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+						}
+						ctx.out.AddrOp(kindOf(typ), exec.OpAssign)
 					} else {
 						ctx.out.StoreField(fieldStructType, fieldIndex)
 					}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -53,8 +53,11 @@ func compileExprLHS(ctx *blockCtx, expr ast.Expr, mode compileMode) {
 		compileStarExprLHS(ctx, v, mode)
 	case *ast.ParenExpr:
 		compileExprLHS(ctx, v.X, mode)
+	case *ast.UnaryExpr:
+		ctx.indirect = !ctx.indirect
+		compileExprLHS(ctx, v.X, mode)
 	default:
-		log.Panicln("compileExpr failed: unknown -", reflect.TypeOf(v))
+		log.Panicln("compileExprLHS failed: unknown -", reflect.TypeOf(v))
 	}
 }
 

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -71,12 +71,18 @@ func compileCallExprLHS(ctx *blockCtx, v *ast.CallExpr, mode token.Token) {
 	compileCallExpr(ctx, v, callExpr)()
 	rv := ctx.infer.Get(-1)
 	lv := ctx.infer.Get(-2)
-	typ := boundType(rv.(iValue))
-	if ctx.indirect > 0 {
+	rt := boundType(rv.(iValue))
+	typ := rt
+	for i := 0; i < ctx.indirect; i++ {
 		typ = typ.Elem()
 	}
 	checkType(typ, lv, ctx.out)
 	ctx.infer.PopN(2)
+	elem := rt
+	for i := 0; i < ctx.indirect-1; i++ {
+		elem = elem.Elem()
+		ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+	}
 	ctx.out.AddrOp(kindOf(typ), exec.OpAssign)
 }
 

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -945,7 +945,8 @@ func compileIndexExprLHS(ctx *blockCtx, v *ast.IndexExpr, mode compileMode) {
 	}
 	exprX()
 	ctx.checkLoadAddr = false
-	if ctx.indirect > 0 {
+	styp := typElem
+	for i := 0; i < ctx.indirect; i++ {
 		typElem = typElem.Elem()
 	}
 	if cons, ok := val.(*constVal); ok {
@@ -962,7 +963,13 @@ func compileIndexExprLHS(ctx *blockCtx, v *ast.IndexExpr, mode compileMode) {
 		if cons, ok := i.(*constVal); ok {
 			n := boundConst(cons.v, exec.TyInt)
 			if ctx.indirect > 0 {
-				ctx.out.Index(n.(int)).AddrOp(kindOf(typElem), exec.OpAssign)
+				ctx.out.Index(n.(int))
+				elem := styp
+				for i := 0; i < ctx.indirect-1; i++ {
+					elem = elem.Elem()
+					ctx.out.AddrOp(kindOf(elem), exec.OpAddrVal)
+				}
+				ctx.out.AddrOp(kindOf(typElem), exec.OpAssign)
 			} else {
 				ctx.out.SetIndex(n.(int))
 			}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1776,6 +1776,14 @@ var testStarExprClauses = map[string]testData{
 					a := 10
 					println(*(*int)(&a))
 					`, "10\n", false},
+	"start addr set": {`
+					a := 10
+					p := &a
+					*p = 20
+					println(a)
+					*(p) = 30
+					println(a)
+	`, "20\n30\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1783,7 +1783,9 @@ var testStarExprClauses = map[string]testData{
 					println(a)
 					*(p) = 30
 					println(a)
-	`, "20\n30\n", false},
+					*(&a) = 40
+					println(a)
+	`, "20\n30\n40\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1885,6 +1885,19 @@ var testStarExprClauses = map[string]testData{
 					***p3--
 					println(v)
 	`, "33\n32\n", false},
+	"star big.Int inc dec multi indirect": {`
+					v := 1r
+					p := &v
+					p1 := &p
+					v++
+					println(v)
+					*p++
+					println(v)
+					**p1++
+					println(v)
+					**p1--
+					println(v)
+	`, "2\n3\n4\n3\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1873,6 +1873,18 @@ var testStarExprClauses = map[string]testData{
 					***m[0] = 30
 					println(***m[0])
 	`, "30\n", false},
+	"star inc dec multi indirect": {`
+					v := 30
+					p1 := &v
+					p2 := &p1
+					p3 := &p2
+					v++
+					**p2++
+					***p3++
+					println(v)
+					***p3--
+					println(v)
+	`, "33\n32\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1804,6 +1804,16 @@ var testStarExprClauses = map[string]testData{
 					***p2 = 30
 					println(v)
 	`, "30\n", false},
+	"start expr multi indirect call": {`
+					func test(v **int) **int {
+						return v
+					}
+					v := 10
+					p := &v
+					p1 := &p
+					**test(p1) = 30
+					println(v)
+	`, "30\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1827,6 +1827,17 @@ var testStarExprClauses = map[string]testData{
 					**pt.X = 30
 					println(**pt.X)
 	`, "30\n", false},
+	"star stack var multi indirect": {`
+					func test(v ***int) {
+						***v = 30
+						println(***v)
+					}
+					v := 10
+					p1 := &v
+					p2 := &p1
+					test(&p2)
+					println(v)
+	`, "30\n30\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1838,6 +1838,16 @@ var testStarExprClauses = map[string]testData{
 					test(&p2)
 					println(v)
 	`, "30\n30\n", false},
+	"star index multi indirect": {`
+					var v1, v2 int
+					p1 := &v1
+					p2 := &v2
+					p3 := &p1
+					p4 := &p2
+					v := []***int{&p3, &p4}
+					***v[0] = 30
+					println(***v[0])
+	`, "30\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1804,7 +1804,7 @@ var testStarExprClauses = map[string]testData{
 					***p2 = 30
 					println(v)
 	`, "30\n", false},
-	"start expr multi indirect call": {`
+	"star expr multi indirect call": {`
 					func test(v **int) **int {
 						return v
 					}
@@ -1813,6 +1813,19 @@ var testStarExprClauses = map[string]testData{
 					p1 := &p
 					**test(p1) = 30
 					println(v)
+	`, "30\n", false},
+	"star selection expr multi indirect": {`
+					type Point struct {
+						X **int
+						Y int
+					}
+					v := 10
+					p1 := &v
+					p2 := &p1
+					pt := &Point{}
+					pt.X = p2
+					**pt.X = 30
+					println(**pt.X)
 	`, "30\n", false},
 }
 

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1838,13 +1838,26 @@ var testStarExprClauses = map[string]testData{
 					test(&p2)
 					println(v)
 	`, "30\n30\n", false},
-	"star index multi indirect": {`
+	"star slice multi indirect": {`
 					var v1, v2 int
 					p1 := &v1
 					p2 := &v2
 					p3 := &p1
 					p4 := &p2
 					v := []***int{&p3, &p4}
+					index := 1
+					***v[0] = 30
+					***v[index] = 40
+					println(***v[0])
+					println(***v[index])
+	`, "30\n40\n", false},
+	"star array multi indirect": {`
+					var v1, v2 int
+					p1 := &v1
+					p2 := &v2
+					p3 := &p1
+					p4 := &p2
+					v := [2]***int{&p3, &p4}
 					index := 1
 					***v[0] = 30
 					***v[index] = 40

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1796,6 +1796,14 @@ var testStarExprClauses = map[string]testData{
 					*((*int)(&v)) = 300
 					println(v)
 	`, "200\n300\n", false},
+	"star expr multi indirect": {`
+					v := 10
+					p := &v
+					p1 := &p
+					p2 := &p1
+					***p2 = 30
+					println(v)
+	`, "30\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1851,6 +1851,15 @@ var testStarExprClauses = map[string]testData{
 					println(***v[0])
 					println(***v[index])
 	`, "30\n40\n", false},
+	"star map multi indirect": {`
+					var v int
+					p1 := &v
+					p2 := &p1
+					m := make(map[int]***int)
+					m[0] = &p2
+					***m[0] = 30
+					println(***m[0])
+	`, "30\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1793,7 +1793,9 @@ var testStarExprClauses = map[string]testData{
 					v := 100
 					*test(&v) = 200
 					println(v)
-	`, "200\n", false},
+					*((*int)(&v)) = 300
+					println(v)
+	`, "200\n300\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1845,9 +1845,12 @@ var testStarExprClauses = map[string]testData{
 					p3 := &p1
 					p4 := &p2
 					v := []***int{&p3, &p4}
+					index := 1
 					***v[0] = 30
+					***v[index] = 40
 					println(***v[0])
-	`, "30\n", false},
+					println(***v[index])
+	`, "30\n40\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1772,11 +1772,11 @@ var testStarExprClauses = map[string]testData{
 					println(a1, *c.b, *c.m["foo"], *c.s[0])
 	
 						`, "3 3 8 11\n", false},
-	"start expr ptr conv": {`
+	"star expr ptr conv": {`
 					a := 10
 					println(*(*int)(&a))
 					`, "10\n", false},
-	"start addr set": {`
+	"star expr ptr set": {`
 					a := 10
 					p := &a
 					*p = 20
@@ -1786,6 +1786,14 @@ var testStarExprClauses = map[string]testData{
 					*(&a) = 40
 					println(a)
 	`, "20\n30\n40\n", false},
+	"star expr call set": {`
+					func test(v *int) *int {
+						return v
+					}
+					v := 100
+					*test(&v) = 200
+					println(v)
+	`, "200\n", false},
 }
 
 func TestStarExpr(t *testing.T) {

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -651,6 +651,7 @@ func compileAssignStmt(ctx *blockCtx, expr *ast.AssignStmt) {
 	}
 	count := len(expr.Lhs)
 	ctx.underscore = 0
+	ctx.indirect = 0
 	for i := len(expr.Lhs) - 1; i >= 0; i-- {
 		compileExprLHS(ctx, expr.Lhs[i], expr.Tok)
 	}

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -613,6 +613,7 @@ func compileSendStmt(ctx *blockCtx, expr *ast.SendStmt) {
 
 func compileIncDecStmt(ctx *blockCtx, expr *ast.IncDecStmt) {
 	compileExpr(ctx, expr.X)()
+	ctx.indirect = 0
 	compileExprLHS(ctx, expr.X, expr.Tok)
 }
 

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -99,12 +99,7 @@ func execOpAddrVal(i Instr, p *Context) {
 func execOpAssign(i Instr, p *Context) {
 	n := len(p.data)
 	v := reflect.ValueOf(p.data[n-2])
-	typ := v.Type()
-	x := reflect.ValueOf(p.data[n-1]).Elem()
-	for x.Type() != typ {
-		x = x.Elem()
-	}
-	x.Set(v)
+	reflect.ValueOf(p.data[n-1]).Elem().Set(v)
 	p.data = p.data[:n-2]
 }
 

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -99,7 +99,12 @@ func execOpAddrVal(i Instr, p *Context) {
 func execOpAssign(i Instr, p *Context) {
 	n := len(p.data)
 	v := reflect.ValueOf(p.data[n-2])
-	reflect.ValueOf(p.data[n-1]).Elem().Set(v)
+	typ := v.Type()
+	x := reflect.ValueOf(p.data[n-1]).Elem()
+	for x.Type() != typ {
+		x = x.Elem()
+	}
+	x.Set(v)
 	p.data = p.data[:n-2]
 }
 

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -258,9 +258,6 @@ func (p *Builder) AddrOp(kind exec.Kind, op exec.AddrOperator) *Builder {
 		})
 		return p
 	}
-	if kind >= exec.BigInt {
-		return p.bigAddrOp(kind, op)
-	}
 	if op == exec.OpAssign {
 		p.emitStmt(&ast.AssignStmt{
 			Lhs: []ast.Expr{&ast.StarExpr{
@@ -270,6 +267,9 @@ func (p *Builder) AddrOp(kind exec.Kind, op exec.AddrOperator) *Builder {
 			Rhs: []ast.Expr{p.rhs.Pop().(ast.Expr)},
 		})
 		return p
+	}
+	if kind >= exec.BigInt {
+		return p.bigAddrOp(kind, op)
 	}
 	var stmt ast.Stmt
 	var x = p.rhs.Pop()

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -284,11 +284,19 @@ func (p *Builder) AddrOp(kind exec.Kind, op exec.AddrOperator) *Builder {
 		} else {
 			stmt = &ast.AssignStmt{Lhs: []ast.Expr{v.X}, Tok: addropTokens[op], Rhs: []ast.Expr{val}}
 		}
-	case *ast.StarExpr:
+	case *ast.Ident:
+		x := &ast.StarExpr{X: v}
 		if op == exec.OpInc || op == exec.OpDec {
-			stmt = &ast.IncDecStmt{X: &ast.StarExpr{X: v}, TokPos: v.Pos(), Tok: addropTokens[op]}
+			stmt = &ast.IncDecStmt{X: x, TokPos: v.Pos(), Tok: addropTokens[op]}
 		} else {
-			stmt = &ast.AssignStmt{Lhs: []ast.Expr{&ast.StarExpr{X: v}}, Tok: addropTokens[op], Rhs: []ast.Expr{val}}
+			stmt = &ast.AssignStmt{Lhs: []ast.Expr{x}, Tok: addropTokens[op], Rhs: []ast.Expr{val}}
+		}
+	case *ast.StarExpr:
+		x := &ast.StarExpr{X: v}
+		if op == exec.OpInc || op == exec.OpDec {
+			stmt = &ast.IncDecStmt{X: x, TokPos: v.Pos(), Tok: addropTokens[op]}
+		} else {
+			stmt = &ast.AssignStmt{Lhs: []ast.Expr{x}, Tok: addropTokens[op], Rhs: []ast.Expr{val}}
 		}
 	default:
 		log.Panicln("AddrOp: todo")

--- a/exec/golang/var.go
+++ b/exec/golang/var.go
@@ -284,6 +284,12 @@ func (p *Builder) AddrOp(kind exec.Kind, op exec.AddrOperator) *Builder {
 		} else {
 			stmt = &ast.AssignStmt{Lhs: []ast.Expr{v.X}, Tok: addropTokens[op], Rhs: []ast.Expr{val}}
 		}
+	case *ast.StarExpr:
+		if op == exec.OpInc || op == exec.OpDec {
+			stmt = &ast.IncDecStmt{X: &ast.StarExpr{X: v}, TokPos: v.Pos(), Tok: addropTokens[op]}
+		} else {
+			stmt = &ast.AssignStmt{Lhs: []ast.Expr{&ast.StarExpr{X: v}}, Tok: addropTokens[op], Rhs: []ast.Expr{val}}
+		}
 	default:
 		log.Panicln("AddrOp: todo")
 	}


### PR DESCRIPTION
fix #680 
cl: fix compileExprLHS indirect addr set, support multi indirect addr operator. 

- support multi indirect inc/dec/assign etc
- support big.Int multi indirect

Go+ code
```
func test(v **int) **int {
	return v
}

// int
v := 1
pv := &v
pv1 := &pv

// inc
v++
*pv++
**pv1++
**pv1 += 4
println(v)

// set
*pv = 20
println(v)
**(&pv) = 30
println(v)
**pv1 = 40
println(v)

// call
**test(&pv) = 20
println(v)
**((**int)(&pv)) = 30
println(v)

// big.Int
b := 1r
pb := &b
pb1 := &pb

// inc
b++
*pb++
**pb1++
**pb1 += 4
println(b)

// set
*pb = 20r
println(b)
**(&pb) = 30r
println(b)
**pb1 += 4r
println(b)
```
generate Golang code
```
package main

import (
	fmt "fmt"
	big "math/big"
)

var (
	v   int
	pv  *int
	pv1 **int
	b   *big.Int
	pb  **big.Int
	pb1 ***big.Int
)

func main() { 
//line ./main.gop:7
	v = 1
//line ./main.gop:8
	pv = &v
//line ./main.gop:9
	pv1 = &pv
//line ./main.gop:12
	v++
//line ./main.gop:13
	*pv++
//line ./main.gop:14
	**pv1++
//line ./main.gop:15
	**pv1 += 4
//line ./main.gop:16
	fmt.Println(v)
//line ./main.gop:19
	*pv = 20
//line ./main.gop:20
	fmt.Println(v)
//line ./main.gop:21
	*pv = 30
//line ./main.gop:22
	fmt.Println(v)
//line ./main.gop:23
	**pv1 = 40
//line ./main.gop:24
	fmt.Println(v)
//line ./main.gop:27
	**test(&pv) = 20
//line ./main.gop:28
	fmt.Println(v)
//line ./main.gop:29
	**(**int)(&pv) = 30
//line ./main.gop:30
	fmt.Println(v)
//line ./main.gop:33
	b = big.NewInt(1)
//line ./main.gop:34
	pb = &b
//line ./main.gop:35
	pb1 = &pb
//line ./main.gop:38
	b.Add(b, big.NewInt(1))
//line ./main.gop:39
	(*pb).Add(*pb, big.NewInt(1))
//line ./main.gop:40
	(**pb1).Add(**pb1, big.NewInt(1))
//line ./main.gop:41
	(**pb1).Add(**pb1, big.NewInt(4))
//line ./main.gop:42
	fmt.Println(b)
//line ./main.gop:45
	*pb = big.NewInt(20)
//line ./main.gop:46
	fmt.Println(b)
//line ./main.gop:47
	*pb = big.NewInt(30)
//line ./main.gop:48
	fmt.Println(b)
//line ./main.gop:49
	(**pb1).Add(**pb1, big.NewInt(4))
//line ./main.gop:50
	fmt.Println(b)
}
func test(_arg_0 **int) (_ret_1 **int) { 
//line ./main.gop:3
	return _arg_0
}
```