### PR TITLE
cl: support const & iota

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -369,16 +369,16 @@ func loadVars(ctx *blockCtx, d *ast.GenDecl, stmt ast.Stmt) {
 }
 
 func loadConst(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {
-	var t reflect.Type
-	if typ != nil {
-		t = toType(ctx, typ).(reflect.Type)
-	}
 	compileExpr(ctx, value)
 	in := ctx.infer.Pop()
-	if t == nil {
-		t = boundType(in.(iValue))
+	c := in.(*constVal)
+	if typ != nil {
+		t := toType(ctx, typ).(reflect.Type)
+		v := boundConst(c.v, t)
+		c.v = v
+		c.kind = t.Kind()
 	}
-	ctx.syms[name] = in.(*constVal)
+	ctx.syms[name] = c
 }
 
 func loadVar(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -316,16 +316,17 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 
 var (
 	iotaIndex int
-	iotaInc   bool
+	iotaUsed  bool
 )
 
 func newIotaValue() *constVal {
-	iotaInc = true
+	iotaUsed = true
 	return newConstVal(iotaIndex, exec.ConstUnboundInt)
 }
 
 func loadConsts(ctx *blockCtx, d *ast.GenDecl) {
 	iotaIndex = 0
+	iotaUsed = false
 	var last *ast.ValueSpec
 	for _, item := range d.Specs {
 		spec := item.(*ast.ValueSpec)
@@ -340,11 +341,10 @@ func loadConsts(ctx *blockCtx, d *ast.GenDecl) {
 		} else if nvalue > nnames {
 			log.Panicf("extra expression in const declaration")
 		} else {
-			iotaInc = false
 			for i := 0; i < nnames; i++ {
 				loadConst(ctx, spec.Names[i].Name, spec.Type, spec.Values[i])
 			}
-			if iotaInc {
+			if iotaUsed {
 				iotaIndex++
 			}
 		}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -318,16 +318,19 @@ func loadConsts(ctx *blockCtx, d *ast.GenDecl) {
 	var last *ast.ValueSpec
 	for _, item := range d.Specs {
 		spec := item.(*ast.ValueSpec)
-		if spec.Type == nil && len(spec.Values) == 0 {
+		if spec.Type == nil && spec.Values == nil {
 			spec.Type = last.Type
 			spec.Values = last.Values
 		}
-		for i := 0; i < len(spec.Names); i++ {
-			name := spec.Names[i].Name
-			if len(spec.Values) > i {
-				loadConst(ctx, name, spec.Type, spec.Values[i])
-			} else {
-				loadConst(ctx, name, spec.Type, nil)
+		nnames := len(spec.Names)
+		nvalue := len(spec.Values)
+		if nvalue < nnames {
+			log.Panicf("missing value in const declaration")
+		} else if nvalue > nnames {
+			log.Panicf("extra expression in const declaration")
+		} else {
+			for i := 0; i < nnames; i++ {
+				loadConst(ctx, spec.Names[i].Name, spec.Type, spec.Values[i])
 			}
 		}
 		last = spec

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -369,6 +369,9 @@ func loadVars(ctx *blockCtx, d *ast.GenDecl, stmt ast.Stmt) {
 }
 
 func loadConst(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {
+	if name != "_" && ctx.exists(name) {
+		log.Panicln("loadConst failed: symbol exists -", name)
+	}
 	compileExpr(ctx, value)
 	in := ctx.infer.Pop()
 	c := in.(*constVal)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -381,7 +381,9 @@ func loadConst(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {
 		c.v = v
 		c.kind = t.Kind()
 	}
-	ctx.syms[name] = c
+	if name != "_" {
+		ctx.syms[name] = c
+	}
 }
 
 func loadVar(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -314,7 +314,18 @@ func loadType(ctx *blockCtx, spec *ast.TypeSpec) {
 	ctx.types[t] = tDecl
 }
 
+var (
+	iotaIndex int
+	iotaInc   bool
+)
+
+func newIotaValue() *constVal {
+	iotaInc = true
+	return newConstVal(iotaIndex, exec.ConstUnboundInt)
+}
+
 func loadConsts(ctx *blockCtx, d *ast.GenDecl) {
+	iotaIndex = 0
 	var last *ast.ValueSpec
 	for _, item := range d.Specs {
 		spec := item.(*ast.ValueSpec)
@@ -329,8 +340,12 @@ func loadConsts(ctx *blockCtx, d *ast.GenDecl) {
 		} else if nvalue > nnames {
 			log.Panicf("extra expression in const declaration")
 		} else {
+			iotaInc = false
 			for i := 0; i < nnames; i++ {
 				loadConst(ctx, spec.Names[i].Name, spec.Type, spec.Values[i])
+			}
+			if iotaInc {
+				iotaIndex++
 			}
 		}
 		last = spec

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -241,9 +241,7 @@ func compileIdent(ctx *blockCtx, ident *ast.Ident, compileByCallExpr bool) func(
 		if name == "iota" {
 			c := newIotaValue()
 			ctx.infer.Push(c)
-			return func() {
-				pushConstVal(ctx.out, c)
-			}
+			return nil
 		}
 		if addr, kind, ok := ctx.builtin.Find(name); ok {
 			switch kind {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -238,6 +238,13 @@ func compileIdent(ctx *blockCtx, ident *ast.Ident, compileByCallExpr bool) func(
 			log.Panicln("compileIdent failed: unknown -", reflect.TypeOf(sym))
 		}
 	} else {
+		if name == "iota" {
+			c := newIotaValue()
+			ctx.infer.Push(c)
+			return func() {
+				pushConstVal(ctx.out, c)
+			}
+		}
 		if addr, kind, ok := ctx.builtin.Find(name); ok {
 			switch kind {
 			case exec.SymbolVar:

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -188,6 +188,12 @@ func compileIdent(ctx *blockCtx, ident *ast.Ident, compileByCallExpr bool) func(
 	}
 	if sym, ok := ctx.find(name); ok {
 		switch v := sym.(type) {
+		case *constVal:
+			c := newConstVal(v.v, v.Kind())
+			ctx.infer.Push(c)
+			return func() {
+				pushConstVal(ctx.out, c)
+			}
 		case *execVar:
 			typ := v.v.Type()
 			kind := typ.Kind()

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1969,6 +1969,11 @@ func TestConst(t *testing.T) {
 
 func TestBadConst(t *testing.T) {
 	cltest.Expect(t, `
+	const x = 0
+	const x = 0
+	println(x)
+	`, "", nil)
+	cltest.Expect(t, `
 	const (
 		v1,v2 = 100
 	)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1953,10 +1953,12 @@ func TestConst(t *testing.T) {
 	const (
 		v1 int = 100
 		v2
-		v3
+		v3 float64 = 100
+		v4 = float64(100)
 	)
-	println(v1,v2,v3)
-	`, "100 100 100\n")
+	println(v1,v2,v3,v4)
+	printf("%T %T %T %T\n",v1,v2,v3,v4)
+	`, "100 100 100 100\nint int float64 float64\n")
 	cltest.Expect(t, `
 	const (
 		v1,v2,v3 = 100,200,300
@@ -1978,4 +1980,29 @@ func TestBadConst(t *testing.T) {
 	)
 	println(v1,v2)
 	`, "", "extra expression in const declaration")
+}
+
+func TestIota(t *testing.T) {
+	cltest.Expect(t, `
+	const (
+		c0 = iota
+		c1
+		c2
+	)
+	const (
+		a = 2 << iota
+		b
+		c = 3
+		d = 2 << iota
+	)
+	const (
+		u         = iota * 42
+		v float64 = iota * 42
+		w         = iota * 42
+	)
+	println(c0,c1,c2)
+	println(a,b,c,d)
+	println(u,v,w)
+	printf("%T %T %T\n",u,v,w)
+	`, "0 1 2\n2 4 3 8\n0 42 84\nint float64 int\n")
 }

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1985,24 +1985,35 @@ func TestBadConst(t *testing.T) {
 func TestIota(t *testing.T) {
 	cltest.Expect(t, `
 	const (
-		c0 = iota
-		c1
-		c2
+		c0 = iota  // c0 == 0
+		c1 = iota  // c1 == 1
+		c2 = iota  // c2 == 2
 	)
 	const (
-		a = 2 << iota
-		b
-		c = 3
-		d = 2 << iota
-	)
-	const (
-		u         = iota * 42
-		v float64 = iota * 42
-		w         = iota * 42
+		a = 1 << iota  // a == 1  (iota == 0)
+		b = 1 << iota  // b == 2  (iota == 1)
+		c = 3          // c == 3  (iota == 2, unused)
+		d = 1 << iota  // d == 8  (iota == 3)
 	)
 	println(c0,c1,c2)
 	println(a,b,c,d)
+	`, "0 1 2\n1 2 3 8\n")
+	cltest.Expect(t, `
+	const (
+		u         = iota * 42  // u == 0     (untyped integer constant)
+		v float64 = iota * 42  // v == 42.0  (float64 constant)
+		w         = iota * 42  // w == 84    (untyped integer constant)
+	)
 	println(u,v,w)
 	printf("%T %T %T\n",u,v,w)
-	`, "0 1 2\n2 4 3 8\n0 42 84\nint float64 int\n")
+	`, "0 42 84\nint float64 int\n")
+	cltest.Expect(t, `
+	const (
+		bit0, mask0 = 1 << iota, 1<<iota - 1  // bit0 == 1, mask0 == 0  (iota == 0)
+		bit1, mask1                           // bit1 == 2, mask1 == 1  (iota == 1)
+		_, _                                  //                        (iota == 2, unused)
+		bit3, mask3                           // bit3 == 8, mask3 == 7  (iota == 3)
+	)
+	println(bit0,mask0,bit1,mask1,bit3,mask3)
+	`, "1 0 2 1 8 7\n")
 }

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1926,3 +1926,22 @@ func TestTwoValueExpr(t *testing.T) {
 			}`
 	cltest.Expect(t, clause, "1 3 true\n3 0 false\n")
 }
+
+func TestConst(t *testing.T) {
+	cltest.Expect(t, `
+	const v = 100
+	a := v
+	b := int64(v)
+	println(a,b)
+	printf("%T %T\n",a,b)
+	`, "100 100\nint int64\n")
+	cltest.Expect(t, `
+	const (
+		v1 = 100
+		v2
+		v3 = "hello"
+		v4
+	)
+	println(v1,v2,v3,v4)
+	`, "100 100 hello hello\n")
+}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1932,16 +1932,50 @@ func TestConst(t *testing.T) {
 	const v = 100
 	a := v
 	b := int64(v)
-	println(a,b)
-	printf("%T %T\n",a,b)
-	`, "100 100\nint int64\n")
+	println(a,b,v)
+	printf("%T %T %T\n",a,b,v)
+	`, "100 100 100\nint int64 int\n")
 	cltest.Expect(t, `
 	const (
 		v1 = 100
-		v2
-		v3 = "hello"
-		v4
+		v2 = 0x64
+		v3 = uint(100)
+		v4 = 100.1
+		v5 = float32(100.1)
+		v6 = 100r
+		v7 = 'd'
+		v8 = "d"
 	)
-	println(v1,v2,v3,v4)
-	`, "100 100 hello hello\n")
+	println(v1,v2,v3,v4,v5,v6,v7,v8)
+	printf("%T %T %T %T %T %T %T %T\n",v1,v2,v3,v4,v5,v6,v7,v8)
+	`, "100 100 100 100.1 100.1 100 100 d\nint int uint float64 float32 *big.Int int32 string\n")
+	cltest.Expect(t, `
+	const (
+		v1 int = 100
+		v2
+		v3
+	)
+	println(v1,v2,v3)
+	`, "100 100 100\n")
+	cltest.Expect(t, `
+	const (
+		v1,v2,v3 = 100,200,300
+	)
+	println(v1,v2,v3)
+	`, "100 200 300\n")
+}
+
+func TestBadConst(t *testing.T) {
+	cltest.Expect(t, `
+	const (
+		v1,v2 = 100
+	)
+	println(v1,v2)
+	`, "", "missing value in const declaration")
+	cltest.Expect(t, `
+	const (
+		v1,v2 = 100,200,300
+	)
+	println(v1,v2)
+	`, "", "extra expression in const declaration")
 }

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -79,8 +79,8 @@ import fmt "fmt"
 var a []float64
 
 func main() {
-	a = []float64{3.2, 1.2, 2.4}
-	a[1] = 1.6
+	a = []float64{float64(3.2), float64(1.2), float64(2.4)}
+	a[1] = float64(1.6)
 	fmt.Println(a[0], &a[1])
 }
 `

--- a/exec/golang/expr.go
+++ b/exec/golang/expr.go
@@ -212,10 +212,7 @@ func Const(p *Builder, val interface{}) ast.Expr {
 	}
 	if kind >= reflect.Float32 && kind <= reflect.Float64 {
 		var expr ast.Expr = FloatConst(v.Float())
-		if t := v.Type(); t != exec.TyFloat64 {
-			expr = TypeCast(p, expr, exec.TyFloat64, t)
-		}
-		return expr
+		return TypeCast(p, expr, exec.TyFloat64, v.Type())
 	}
 	if kind >= reflect.Complex64 && kind <= reflect.Complex128 {
 		var expr ast.Expr = ComplexConst(v.Complex())


### PR DESCRIPTION
fix #682 
fix #684 
- support constant declarations 
- predeclared identifier iota
- fix golang const float64 typecast

Go+ code
```
const Pi float64 = 3.14159265358979323846
const zero = 0.0         // untyped floating-point constant
const (
	size int64 = 1024
	eof        = -1  // untyped integer constant
)
const va, vb, vc = 3, 4, "foo"  // a = 3, b = 4, c = "foo", untyped integer and string constants
const fu, fv float32 = 0, 3    // u = 0.0, v = 3.0

const (
	c0 = iota  // c0 == 0
	c1 = iota  // c1 == 1
	c2 = iota  // c2 == 2
)

const (
	a = 1 << iota  // a == 1  (iota == 0)
	b = 1 << iota  // b == 2  (iota == 1)
	c = 3          // c == 3  (iota == 2, unused)
	d = 1 << iota  // d == 8  (iota == 3)
)

const (
	u         = iota * 42  // u == 0     (untyped integer constant)
	v float64 = iota * 42  // v == 42.0  (float64 constant)
	w         = iota * 42  // w == 84    (untyped integer constant)
)

const x = iota  // x == 0
const y = iota  // y == 0

const (
	bit0, mask0 = 1 << iota, 1<<iota - 1  // bit0 == 1, mask0 == 0  (iota == 0)
	bit1, mask1                           // bit1 == 2, mask1 == 1  (iota == 1)
	_, _                                  //                        (iota == 2, unused)
	bit3, mask3                           // bit3 == 8, mask3 == 7  (iota == 3)
)

println(Pi)
println(zero,size,eof)
println(va,vb,vc)
println(fu,fv)

println(c0,c1,c2)
println(a,b,c,d)
println(x,y)
println(u,v,w)
println(bit0,mask0,bit1,mask1,bit3,mask3)
```

generate Golang code
```
package main

import fmt "fmt"

func main() { 
//line ./main.gop:40
	fmt.Println(float64(3.141592653589793))
//line ./main.gop:41
	fmt.Println(float64(0), int64(1024), -1)
//line ./main.gop:42
	fmt.Println(3, 4, "foo")
//line ./main.gop:43
	fmt.Println(float32(0), float32(3))
//line ./main.gop:45
	fmt.Println(0, 1, 2)
//line ./main.gop:46
	fmt.Println(1, 2, 3, 8)
//line ./main.gop:47
	fmt.Println(0, 0)
//line ./main.gop:48
	fmt.Println(0, float64(42), 84)
//line ./main.gop:49
	fmt.Println(1, 0, 2, 1, 8, 7)
}
```