### PR TITLE
shift operations type check

### DIFF
--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -175,6 +175,8 @@ func IsPtrKind(kind reflect.Kind) bool {
 func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(t, b)
+	} else if lsh, ok := v.(*lshValue); ok {
+		lsh.bound(t)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()
@@ -201,6 +203,8 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 func checkIntType(v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(exec.TyInt, b)
+	} else if lsh, ok := v.(*lshValue); ok {
+		lsh.bound(exec.TyInt)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -335,7 +335,6 @@ func loadVar(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {
 		t = toType(ctx, typ).(reflect.Type)
 	}
 	if value != nil {
-		ctx.checkType = t
 		expr := compileExpr(ctx, value)
 		in := ctx.infer.Get(-1)
 		if t == nil {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -335,10 +335,13 @@ func loadVar(ctx *blockCtx, name string, typ ast.Expr, value ast.Expr) {
 		t = toType(ctx, typ).(reflect.Type)
 	}
 	if value != nil {
+		ctx.checkType = t
 		expr := compileExpr(ctx, value)
 		in := ctx.infer.Get(-1)
 		if t == nil {
 			t = boundType(in.(iValue))
+		} else if lsh, ok := in.(*lshValue); ok {
+			lsh.bound(t)
 		}
 		expr()
 		addr := ctx.insertVar(name, t)

--- a/cl/context.go
+++ b/cl/context.go
@@ -190,6 +190,7 @@ type blockCtx struct {
 	fieldStructType reflect.Type
 	fieldIndex      []int
 	fieldExprX      func()
+	checkType       reflect.Type
 	underscore      int
 }
 

--- a/cl/context.go
+++ b/cl/context.go
@@ -190,7 +190,6 @@ type blockCtx struct {
 	fieldStructType reflect.Type
 	fieldIndex      []int
 	fieldExprX      func()
-	checkType       reflect.Type
 	underscore      int
 }
 

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1926,3 +1926,63 @@ func TestTwoValueExpr(t *testing.T) {
 			}`
 	cltest.Expect(t, clause, "1 3 true\n3 0 false\n")
 }
+
+func TestOpLsh(t *testing.T) {
+	cltest.Expect(t, `
+	var a [1024]byte
+	var s uint = 33
+	
+	// The results of the following examples are given for 64-bit ints.
+	var i = 1<<s                   // 1 has type int
+	var j int32 = 1<<s             // 1 has type int32; j == 0
+	var k = uint64(1<<s)           // 1 has type uint64; k == 1<<33
+	var m int = 1.0<<s             // 1.0 has type int; m == 1<<33
+	var n = 1.0<<s == j            // 1.0 has type int; n == true
+	var o = 1<<s == 2<<s           // 1 and 2 have type int; o == false
+	var p = 1<<s == 1<<33          // 1 has type int; p == true
+	var w int64 = 1.0<<33          // 1.0<<33 is a constant shift expression; w == 1<<33
+	var x = a[1.0<<(s-30)]         // 1.0 has type int
+	var b = make([]byte, 1.0<<s)   // 1.0 has type int; len(b) == 1<<33
+	printf("%T %T %T %T %T %T %T %T %T %T\n",i,j,k,m,n,o,p,w,x,b)
+	`, "int int32 uint64 int bool bool bool int64 uint8 []uint8\n")
+	cltest.Expect(t, `
+	func test1(v int) {
+		printf("%T\n",v)
+	}
+	func test2(v int32) {
+		printf("%T\n",v)
+	}
+	func test3(v int64) {
+		printf("%T\n",v)
+	}
+	func test4(fmt string,v ...int32) {
+		printf(fmt,v)
+	}
+	var s uint = 33
+	test1(1<<s)
+	test2(1<<s)
+	test3(1<<s)
+	test4("%T\n",1<<s)
+	`, "int\nint32\nint64\n[]int32\n")
+	cltest.Expect(t, `
+	var s uint = 33
+	var u = 1.0<<s
+	println(u)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s uint = 33
+	var u1 = 1.0<<s != 0
+	println(u1)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s uint = 33
+	var v float32 = 1<<s
+	println(v)
+	`, "", nil)
+	cltest.Expect(t, `
+	var a [1024]byte
+	var s uint = 33
+	var x = a[1.0<<s]
+	println(x)
+	`, "", nil)
+}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1942,9 +1942,9 @@ func TestOpLsh(t *testing.T) {
 	var p = 1<<s == 1<<33          // 1 has type int; p == true
 	var w int64 = 1.0<<33          // 1.0<<33 is a constant shift expression; w == 1<<33
 	var x = a[1.0<<(s-30)]         // 1.0 has type int
-	var b = make([]byte, 1.0<<s)   // 1.0 has type int; len(b) == 1<<33
-	printf("%T %T %T %T %T %T %T %T %T %T\n",i,j,k,m,n,o,p,w,x,b)
-	`, "int int32 uint64 int bool bool bool int64 uint8 []uint8\n")
+	//var b = make([]byte, 1.0<<s)   // 1.0 has type int; len(b) == 1<<33
+	printf("%T %T %T %T %T %T %T %T %T\n",i,j,k,m,n,o,p,w,x)
+	`, "int int32 uint64 int bool bool bool int64 uint8\n")
 	cltest.Expect(t, `
 	func test1(v int) {
 		printf("%T\n",v)

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -247,7 +247,8 @@ func igoMake(ctx *blockCtx, v *ast.CallExpr, ct callType) func() {
 	return func() {
 		n1 := len(v.Args) - 1
 		for i := 1; i <= n1; i++ {
-			compileExpr(ctx, v.Args[i])()
+			expr := compileExpr(ctx, v.Args[i])
+			expr()
 			checkIntType(ctx.infer.Pop(), ctx.out)
 		}
 		if kind == reflect.Slice && n1 == 0 {
@@ -437,6 +438,9 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 			return func() {
 				pushConstVal(ctx.out, cons)
 			}
+		}
+		if lsh, ok := in.(*lshValue); ok {
+			lsh.bound(typ)
 		}
 	}
 	ctx.infer.Ret(1, &goValue{typ})


### PR DESCRIPTION
https://golang.google.cn/ref/spec#Operators

**Not ready**



Go+ code
```
func test1(v int) {
	printf("%v %T\n",v,v)
}
func test2(v int32) {
	printf("%v %T\n",v,v)
}
func test3(v int64) {
	printf("%v %T\n",v,v)
}
func test4(fmt string,v ...int32) {
	printf(fmt,v)
}

var a [1024]byte
var s uint = 33

// The results of the following examples are given for 64-bit ints.
var i = 1<<s                   // 1 has type int
var j int32 = 1<<s             // 1 has type int32; j == 0
var k = uint64(1<<s)           // 1 has type uint64; k == 1<<33
var m int = 1.0<<s             // 1.0 has type int; m == 1<<33
var n = 1.0<<s == j            // 1.0 has type int; n == true
var o = 1<<s == 2<<s           // 1 and 2 have type int; o == false
var p = 1<<s == 1<<33          // 1 has type int; p == true
//var u = 1.0<<s                 // illegal: 1.0 has type float64, cannot shift
//var u1 = 1.0<<s != 0           // illegal: 1.0 has type float64, cannot shift
//var u2 = 1<<s != 1.0           // illegal: 1 has type float64, cannot shift
//var v float32 = 1<<s           // illegal: 1 has type float32, cannot shift
var w int64 = 1.0<<33          // 1.0<<33 is a constant shift expression; w == 1<<33
//var x = a[1.0<<s]              // panics: 1.0 has type int, but 1<<33 overflows array bounds
var x = a[1.0<<(s-30)]
var b = make([]byte, 1.0<<s)   // 1.0 has type int; len(b) == 1<<33

test1(1<<s)
test2(1<<s)
test3(1<<s)
test4("%T\n",1<<s,1<<(s-2))

printf("%v %T\n",i,i)
printf("%v %T\n",j,j)
printf("%v %T\n",k,k)
printf("%v %T\n",m,m)
printf("%v %T\n",n,n)
printf("%v %T\n",o,p)
printf("%v %T\n",w,w)
printf("%v %T\n",x,x)
printf("%v %T\n",b[0],b)
```
generate Golang code
```
package main

import fmt "fmt"

var (
	a [1024]uint8
	s uint
	i int
	j int32
	k uint64
	m int
	n bool
	o bool
	p bool
	w int64
	x uint8
	b []uint8
)

func main() { 
//line ./main.gop:16
	s = uint(33)
//line ./main.gop:19
	i = 1 << s
//line ./main.gop:20
	j = int32(1) << s
//line ./main.gop:21
	k = uint64(uint64(1) << s)
//line ./main.gop:22
	m = 1 << s
//line ./main.gop:23
	n = int32(1)<<s == j
//line ./main.gop:24
	o = 1<<s == 2<<s
//line ./main.gop:25
	p = 1<<s == 1<<33
//line ./main.gop:30
	w = int64(1) << 33
//line ./main.gop:32
	x = a[1<<(s-uint(30))]
//line ./main.gop:33
	b = make([]uint8, 1<<s)
//line ./main.gop:35
	test1(1 << s)
//line ./main.gop:36
	test2(int32(1) << s)
//line ./main.gop:37
	test3(int64(1) << s)
//line ./main.gop:38
	test4("%T\n", int32(1)<<s, int32(1)<<(s-uint(2)))
//line ./main.gop:40
	fmt.Printf("%v %T\n", i, i)
//line ./main.gop:41
	fmt.Printf("%v %T\n", j, j)
//line ./main.gop:42
	fmt.Printf("%v %T\n", k, k)
//line ./main.gop:43
	fmt.Printf("%v %T\n", m, m)
//line ./main.gop:44
	fmt.Printf("%v %T\n", n, n)
//line ./main.gop:45
	fmt.Printf("%v %T\n", o, p)
//line ./main.gop:46
	fmt.Printf("%v %T\n", w, w)
//line ./main.gop:47
	fmt.Printf("%v %T\n", x, x)
//line ./main.gop:48
	fmt.Printf("%v %T\n", b[0], b)
}
func test4(_arg_0 string, _arg_1 ...int32) { 
//line ./main.gop:12
	fmt.Printf(_arg_0, _arg_1)
}
func test2(_arg_0 int32) { 
//line ./main.gop:6
	fmt.Printf("%v %T\n", _arg_0, _arg_0)
}
func test1(_arg_0 int) { 
//line ./main.gop:3
	fmt.Printf("%v %T\n", _arg_0, _arg_0)
}
func test3(_arg_0 int64) { 
//line ./main.gop:9
	fmt.Printf("%v %T\n", _arg_0, _arg_0)
}

```