### PR TITLE
shift operations type check

### DIFF
--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -176,7 +176,7 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(t, b)
 	} else if lsh, ok := v.(*lshValue); ok {
-		lsh.Update(t)
+		lsh.checkType(t)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()
@@ -204,7 +204,7 @@ func checkIntType(v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(exec.TyInt, b)
 	} else if lsh, ok := v.(*lshValue); ok {
-		lsh.Update(exec.TyInt)
+		lsh.checkType(exec.TyInt)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()

--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -175,6 +175,8 @@ func IsPtrKind(kind reflect.Kind) bool {
 func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(t, b)
+	} else if lsh, ok := v.(*lshValue); ok {
+		lsh.Update(t)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()

--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -203,6 +203,8 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 func checkIntType(v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(exec.TyInt, b)
+	} else if lsh, ok := v.(*lshValue); ok {
+		lsh.Update(exec.TyInt)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -671,7 +671,10 @@ func compileBinaryExpr(ctx *blockCtx, v *ast.BinaryExpr) func() {
 	ycons, yok := y.(*constVal)
 	if xok && yok { // <const> op <const>
 		if op == exec.OpLsh && xcons.kind == exec.ConstUnboundFloat {
-			// TODO
+			v := xcons.v.(float64)
+			if v != float64(int64(v)) {
+				log.Panicf("constant %v truncated to integer", v)
+			}
 			xcons.kind = exec.ConstUnboundInt
 		}
 		ret := binaryOp(op, xcons, ycons)

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -659,11 +659,9 @@ func compileBinaryExpr(ctx *blockCtx, v *ast.BinaryExpr) func() {
 	xcons, xok := x.(*constVal)
 	ycons, yok := y.(*constVal)
 	var kind iKind
-	var lshcheck bool
 	var lsh *lshValue
 	if op == exec.OpLsh && xok && !isConstBound(xcons.kind) {
 		kind = xcons.kind
-		lshcheck = true
 		lsh = &lshValue{x: xcons, r: exec.InvalidReserved}
 		ctx.infer.Ret(2, lsh)
 	} else {
@@ -690,7 +688,7 @@ func compileBinaryExpr(ctx *blockCtx, v *ast.BinaryExpr) func() {
 			}
 		}
 		exprY()
-		if lshcheck {
+		if lsh != nil {
 			if !isConstBound(xcons.kind) {
 				lsh.r = ctx.out.ReserveOpLsh()
 				lsh.update = func(kind reflect.Kind) {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -692,14 +692,14 @@ func compileBinaryExpr(ctx *blockCtx, v *ast.BinaryExpr) func() {
 		exprY()
 		if lshcheck {
 			if !isConstBound(xcons.kind) {
-				lsh.r = ctx.out.Reserve()
+				lsh.r = ctx.out.ReserveOpLsh()
 				lsh.update = func(kind reflect.Kind) {
 					xcons.v = boundConst(xcons.v, exec.TypeFromKind(kind))
 					checkBinaryOp(kind, op, x, y, ctx.out)
 					if err := checkOpMatchType(op, x, y); err != nil {
 						log.Panicf("invalid operator: %v (%v)", ctx.code(v), err)
 					}
-					ctx.out.ReservedAsBuiltinOp(lsh.r, kind, op)
+					ctx.out.ReservedAsOpLsh(lsh.r, kind, op)
 				}
 				if label != nil {
 					ctx.out.Label(label)

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1992,6 +1992,10 @@ func TestOpLsh(t *testing.T) {
 	var x = a[1.0<<s]
 	println(x)
 	`, "", nil)
+	cltest.Expect(t, `
+	var s = 1.1 << 33
+	println(s)
+	`, "", "constant 1.1 truncated to integer")
 }
 
 func TestConst(t *testing.T) {

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1926,3 +1926,70 @@ func TestTwoValueExpr(t *testing.T) {
 			}`
 	cltest.Expect(t, clause, "1 3 true\n3 0 false\n")
 }
+
+func TestOpLsh(t *testing.T) {
+	cltest.Expect(t, `
+	var a [1024]byte
+	var s uint = 33
+	// The results of the following examples are given for 64-bit ints.
+	var i = 1<<s                   // 1 has type int
+	var j int32 = 1<<s             // 1 has type int32; j == 0
+	var k = uint64(1<<s)           // 1 has type uint64; k == 1<<33
+	var m int = 1.0<<s             // 1.0 has type int; m == 1<<33
+	var n = 1.0<<s == j            // 1.0 has type int; n == true
+	var o = 1<<s == 2<<s           // 1 and 2 have type int; o == false
+	var p = 1<<s == 1<<33          // 1 has type int; p == true
+	var w int64 = 1.0<<33          // 1.0<<33 is a constant shift expression; w == 1<<33
+	var x = a[1.0<<(s-30)]         // 1.0 has type int
+	//var b = make([]byte, 1.0<<s)   // 1.0 has type int; len(b) == 1<<33
+	printf("%T %T %T %T %T %T %T %T %T\n",i,j,k,m,n,o,p,w,x)
+	`, "int int32 uint64 int bool bool bool int64 uint8\n")
+	cltest.Expect(t, `
+	func test1(v int) {
+		printf("%T\n",v)
+	}
+	func test2(v int32) {
+		printf("%T\n",v)
+	}
+	func test3(v int64) {
+		printf("%T\n",v)
+	}
+	func test4(fmt string,v ...int32) {
+		printf(fmt,v)
+	}
+	var s uint = 33
+	test1(1<<s)
+	test2(1<<s)
+	test3(1<<s)
+	test4("%T\n",1<<s)
+	`, "int\nint32\nint64\n[]int32\n")
+	cltest.Expect(t, `
+	var a int
+	var b int32
+	var c int64
+	var s uint = 33
+	a,b,c = 1<<s,1<<s,1<<s
+	printf("%T %T %T\n",a,b,c)
+	`, "int int32 int64\n")
+	cltest.Expect(t, `
+	var s uint = 33
+	var u = 1.0<<s
+	println(u)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s uint = 33
+	var u1 = 1.0<<s != 0
+	println(u1)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s uint = 33
+	var v float32 = 1<<s
+	println(v)
+	`, "", nil)
+	cltest.Expect(t, `
+	var a [1024]byte
+	var s uint = 33
+	var x = a[1.0<<s]
+	println(x)
+	`, "", nil)
+}

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -438,6 +438,9 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 				pushConstVal(ctx.out, cons)
 			}
 		}
+		if lsh, ok := in.(*lshValue); ok {
+			lsh.Update(typ)
+		}
 	}
 	ctx.infer.Ret(1, &goValue{typ})
 	return func() {

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -442,7 +442,7 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 			}
 		}
 		if lsh, ok := in.(*lshValue); ok {
-			lsh.Update(typ)
+			lsh.bound(typ)
 		}
 	}
 	ctx.infer.Ret(1, &goValue{typ})

--- a/cl/value.go
+++ b/cl/value.go
@@ -48,6 +48,42 @@ func isBool(v iValue) bool {
 
 // -----------------------------------------------------------------------------
 
+type lshValue struct {
+	x      *constVal
+	r      exec.Reserved
+	update func(kind reflect.Kind)
+}
+
+func (p *lshValue) Update(t reflect.Type) {
+	if p.r == exec.InvalidReserved {
+		p.bound(t)
+		return
+	}
+	p.update(t.Kind())
+}
+
+func (p *lshValue) bound(t reflect.Type) {
+	v := boundConst(p.x.v, t)
+	p.x.v = v
+	p.x.kind = t.Kind()
+}
+
+func (p *lshValue) Kind() iKind {
+	return p.x.kind
+}
+
+func (p *lshValue) Type() reflect.Type {
+	return boundType(p.x)
+}
+
+func (p *lshValue) NumValues() int {
+	return 1
+}
+
+func (p *lshValue) Value(i int) iValue {
+	return p
+}
+
 type goValue struct {
 	t reflect.Type
 }

--- a/cl/value.go
+++ b/cl/value.go
@@ -49,17 +49,13 @@ func isBool(v iValue) bool {
 // -----------------------------------------------------------------------------
 
 type lshValue struct {
-	x      *constVal
-	r      exec.Reserved
-	update func(kind reflect.Kind)
+	x           *constVal
+	r           exec.Reserved
+	fnCheckType func(typ reflect.Type)
 }
 
-func (p *lshValue) Update(t reflect.Type) {
-	if p.r == exec.InvalidReserved {
-		p.bound(t)
-		return
-	}
-	p.update(t.Kind())
+func (p *lshValue) checkType(t reflect.Type) {
+	p.fnCheckType(t)
 }
 
 func (p *lshValue) bound(t reflect.Type) {

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -374,8 +374,11 @@ type Builder interface {
 	// ReservedAsPush sets Reserved as Push(v)
 	ReservedAsPush(r Reserved, v interface{})
 
-	// ReservedAsBuiltinOp sets Reserved as BuiltinOp instr
-	ReservedAsBuiltinOp(r Reserved, kind Kind, op Operator)
+	// ReserveOpLsh reserves an instruction.
+	ReserveOpLsh() Reserved
+
+	// ReservedAsOpLsh sets Reserved as OpLsh
+	ReservedAsOpLsh(r Reserved, kind Kind, op Operator)
 
 	// GetPackage returns the Go+ package that the Builder works for.
 	GetPackage() Package

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -374,6 +374,9 @@ type Builder interface {
 	// ReservedAsPush sets Reserved as Push(v)
 	ReservedAsPush(r Reserved, v interface{})
 
+	// ReservedAsBuiltinOp sets Reserved as BuiltinOp instr
+	ReservedAsBuiltinOp(r Reserved, kind Kind, op Operator)
+
 	// GetPackage returns the Go+ package that the Builder works for.
 	GetPackage() Package
 

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -488,6 +488,11 @@ func (p *iBuilder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	((*Builder)(p)).ReservedAsPush(r, v)
 }
 
+// ReservedAsBuiltinOp sets Reserved as GoBuiltin
+func (p *iBuilder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	((*Builder)(p)).ReservedAsBuiltinOp(r, kind, op)
+}
+
 // GetPackage returns the Go+ package that the Builder works for.
 func (p *iBuilder) GetPackage() exec.Package {
 	return NewPackage(p.code)

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -488,9 +488,14 @@ func (p *iBuilder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	((*Builder)(p)).ReservedAsPush(r, v)
 }
 
-// ReservedAsBuiltinOp sets Reserved as GoBuiltin
-func (p *iBuilder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) {
-	((*Builder)(p)).ReservedAsBuiltinOp(r, kind, op)
+// ReserveOpLsh reserves an instruction.
+func (p *iBuilder) ReserveOpLsh() exec.Reserved {
+	return ((*Builder)(p)).Reserve()
+}
+
+// ReservedAsOpLsh sets Reserved as GoBuiltin
+func (p *iBuilder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	((*Builder)(p)).ReservedAsOpLsh(r, kind, op)
 }
 
 // GetPackage returns the Go+ package that the Builder works for.

--- a/exec/bytecode/operator.go
+++ b/exec/bytecode/operator.go
@@ -279,8 +279,8 @@ func (p *Builder) BuiltinOp(kind Kind, op Operator) *Builder {
 	return p
 }
 
-// ReservedAsBuiltinOp instr
-func (p *Builder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) *Builder {
+// ReservedAsOpLsh instr
+func (p *Builder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) *Builder {
 	log.Debug("BuiltinOp:", kind, op)
 	err := p.code.reservedBuiltinOp(int(r), kind, op)
 	if err != nil {

--- a/exec/bytecode/operator.go
+++ b/exec/bytecode/operator.go
@@ -260,13 +260,13 @@ func (p *Code) builtinOp(kind Kind, op Operator) error {
 	return fmt.Errorf("builtinOp: type %v doesn't support operator %v", kind, op)
 }
 
-func (p *Code) reservedBuiltinOp(index int, kind Kind, op Operator) error {
+func (p *Code) reservedAsOpLsh(index int, kind Kind, op Operator) error {
 	i := (int(kind) << bitsOperator) | int(op)
 	if fn := builtinOps[i]; fn != nil {
 		p.data[index] = (opBuiltinOp << bitsOpShift) | uint32(i)
 		return nil
 	}
-	return fmt.Errorf("builtinOp: type %v doesn't support operator %v", kind, op)
+	return fmt.Errorf("reservedAsOpLsh: type %v doesn't support operator %v", kind, op)
 }
 
 // BuiltinOp instr
@@ -281,8 +281,8 @@ func (p *Builder) BuiltinOp(kind Kind, op Operator) *Builder {
 
 // ReservedAsOpLsh instr
 func (p *Builder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) *Builder {
-	log.Debug("BuiltinOp:", kind, op)
-	err := p.code.reservedBuiltinOp(int(r), kind, op)
+	log.Debug("ReservedAsOpLsh:", kind, op)
+	err := p.code.reservedAsOpLsh(int(r), kind, op)
 	if err != nil {
 		panic(err)
 	}

--- a/exec/bytecode/operator.go
+++ b/exec/bytecode/operator.go
@@ -260,10 +260,29 @@ func (p *Code) builtinOp(kind Kind, op Operator) error {
 	return fmt.Errorf("builtinOp: type %v doesn't support operator %v", kind, op)
 }
 
+func (p *Code) reservedBuiltinOp(index int, kind Kind, op Operator) error {
+	i := (int(kind) << bitsOperator) | int(op)
+	if fn := builtinOps[i]; fn != nil {
+		p.data[index] = (opBuiltinOp << bitsOpShift) | uint32(i)
+		return nil
+	}
+	return fmt.Errorf("builtinOp: type %v doesn't support operator %v", kind, op)
+}
+
 // BuiltinOp instr
 func (p *Builder) BuiltinOp(kind Kind, op Operator) *Builder {
 	log.Debug("BuiltinOp:", kind, op)
 	err := p.code.builtinOp(kind, op)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// ReservedAsBuiltinOp instr
+func (p *Builder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) *Builder {
+	log.Debug("BuiltinOp:", kind, op)
+	err := p.code.reservedBuiltinOp(int(r), kind, op)
 	if err != nil {
 		panic(err)
 	}

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -368,6 +368,22 @@ func (p *Builder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	p.reserveds[r].Expr = Const(p, v)
 }
 
+// ReservedAsBuiltinOp sets Reserved as GoBuiltin
+func (p *Builder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	tok := opTokens[op]
+	if tok == token.ILLEGAL {
+		log.Panicln("BuiltinOp: unsupported op -", op)
+	}
+	oi := op.GetInfo()
+	val := p.reserveds[r].Expr
+	if oi.InSecond == 0 {
+		p.reserveds[r].Expr = &ast.UnaryExpr{Op: tok, X: val}
+		return
+	}
+	x := p.reserveds[r].Expr
+	p.reserveds[r].Expr = &ast.BinaryExpr{Op: tok, X: x, Y: val}
+}
+
 // Pop instr
 func (p *Builder) Pop(n int) *Builder {
 	log.Panicln("todo")

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -378,8 +378,8 @@ type reserveLsh struct {
 func (p *Builder) ReserveOpLsh() exec.Reserved {
 	r := &reserveLsh{}
 	r.expr = new(printer.ReservedExpr)
-	r.x = p.rhs.Pop().(ast.Expr)
 	r.y = p.rhs.Pop().(ast.Expr)
+	r.x = p.rhs.Pop().(ast.Expr)
 	idx := len(p.reserveds)
 	p.reserveds = append(p.reserveds, r)
 	p.rhs.Push(r.expr)

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/goplus/gop/cl"
 	"github.com/goplus/gop/exec.spec"
+	"github.com/goplus/gop/exec/golang/internal/go/printer"
 	"github.com/qiniu/x/log"
 
 	qexec "github.com/goplus/gop/exec/bytecode"
@@ -491,7 +492,7 @@ func TestReserved(t *testing.T) {
 	code := NewBuilder("main", nil, nil)
 	off := code.Reserve()
 	code.ReservedAsPush(off, 123)
-	if !reflect.DeepEqual(code.reserveds[off].Expr.(*ast.BasicLit), IntConst(123)) {
+	if !reflect.DeepEqual(code.reserveds[off].(*printer.ReservedExpr).Expr.(*ast.BasicLit), IntConst(123)) {
 		t.Fatal("TestReserved failed: reserveds is not set to", 123)
 	}
 }
@@ -510,7 +511,7 @@ func TestConstNil(t *testing.T) {
 	} {
 		off := code.Reserve()
 		code.ReservedAsPush(off, v)
-		if code.reserveds[off].Expr.(*ast.Ident).Name != "nil" {
+		if code.reserveds[off].(*printer.ReservedExpr).Expr.(*ast.Ident).Name != "nil" {
 			t.Fatal("TestConstNil failed: reserveds is not set nil")
 		}
 	}

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -505,9 +505,14 @@ func (p *iBuilder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	((*Builder)(p)).ReservedAsPush(r, v)
 }
 
-// ReservedAsBuiltinOp sets Reserved as GoBuiltin
-func (p *iBuilder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) {
-	((*Builder)(p)).ReservedAsBuiltinOp(r, kind, op)
+// ReserveOpLsh reserves an instruction.
+func (p *iBuilder) ReserveOpLsh() exec.Reserved {
+	return ((*Builder)(p)).ReserveOpLsh()
+}
+
+// ReservedAsOpLsh sets Reserved as GoBuiltin
+func (p *iBuilder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	((*Builder)(p)).ReservedAsOpLsh(r, kind, op)
 }
 
 // GetPackage returns the Go+ package that the Builder works for.

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -505,6 +505,11 @@ func (p *iBuilder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	((*Builder)(p)).ReservedAsPush(r, v)
 }
 
+// ReservedAsBuiltinOp sets Reserved as GoBuiltin
+func (p *iBuilder) ReservedAsBuiltinOp(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	((*Builder)(p)).ReservedAsBuiltinOp(r, kind, op)
+}
+
 // GetPackage returns the Go+ package that the Builder works for.
 func (p *iBuilder) GetPackage() exec.Package {
 	return defaultImpl

--- a/exec/golang/testdata/33.left-shift/left_shift.gop
+++ b/exec/golang/testdata/33.left-shift/left_shift.gop
@@ -30,7 +30,7 @@ var p = 1<<s == 1<<33  // 1 has type int; p == true
 var w int64 = 1.0 << 33 // 1.0<<33 is a constant shift expression; w == 1<<33
 // var x = a[1.0<<s]              // panics: 1.0 has type int, but 1<<33 overflows array bounds
 var x = a[1.0<<(s-30)]
-var b = make([]byte, 1.0<<s) // 1.0 has type int; len(b) == 1<<33
+var b = make([]byte, 1.0<<(s-30)) // 1.0 has type int; len(b) == 1<<33
 q = 1.0 << (s - 30)
 
 test1(1 << s)
@@ -48,4 +48,4 @@ printf("%v %T\n", p, p)
 printf("%v %T\n", q, q)
 printf("%v %T\n", w, w)
 printf("%v %T\n", x, x)
-printf("%v %T\n", b[0], b)
+printf("%v %T\n", len(b), b)

--- a/exec/golang/testdata/33.left-shift/left_shift.gop
+++ b/exec/golang/testdata/33.left-shift/left_shift.gop
@@ -1,0 +1,51 @@
+func test1(v int) {
+	printf("test1 %v %T\n", v, v)
+}
+func test2(v int32) {
+	printf("test2 %v %T\n", v, v)
+}
+func test3(v int64) {
+	printf("test3 %v %T\n", v, v)
+}
+func test4(v ...int32) {
+	printf("test4 %v %T\n", v, v)
+}
+
+var a [1024]byte
+var s uint = 33
+var q int16
+
+// The results of the following examples are given for 64-bit ints.
+var i = 1 << s         // 1 has type int
+var j int32 = 1 << s   // 1 has type int32; j == 0
+var k = uint64(1 << s) // 1 has type uint64; k == 1<<33
+var m int = 1.0 << s   // 1.0 has type int; m == 1<<33
+var n = 1.0<<s == j    // 1.0 has type int; n == true
+var o = 1<<s == 2<<s   // 1 and 2 have type int; o == false
+var p = 1<<s == 1<<33  // 1 has type int; p == true
+// var u = 1.0<<s                 // illegal: 1.0 has type float64, cannot shift
+// var u1 = 1.0<<s != 0           // illegal: 1.0 has type float64, cannot shift
+// var u2 = 1<<s != 1.0           // illegal: 1 has type float64, cannot shift
+// var v float32 = 1<<s           // illegal: 1 has type float32, cannot shift
+var w int64 = 1.0 << 33 // 1.0<<33 is a constant shift expression; w == 1<<33
+// var x = a[1.0<<s]              // panics: 1.0 has type int, but 1<<33 overflows array bounds
+var x = a[1.0<<(s-30)]
+var b = make([]byte, 1.0<<s) // 1.0 has type int; len(b) == 1<<33
+q = 1.0 << (s - 30)
+
+test1(1 << s)
+test2(1 << s)
+test3(1 << s)
+test4(1<<s, 1<<(s-2))
+
+printf("%v %T\n", i, i)
+printf("%v %T\n", j, j)
+printf("%v %T\n", k, k)
+printf("%v %T\n", m, m)
+printf("%v %T\n", n, n)
+printf("%v %T\n", o, o)
+printf("%v %T\n", p, p)
+printf("%v %T\n", q, q)
+printf("%v %T\n", w, w)
+printf("%v %T\n", x, x)
+printf("%v %T\n", b[0], b)


### PR DESCRIPTION
fix #685
https://golang.google.cn/ref/spec#Operators

Go+ code
```
func test1(v int) {
	printf("test1 %v %T\n", v, v)
}
func test2(v int32) {
	printf("test2 %v %T\n", v, v)
}
func test3(v int64) {
	printf("test3 %v %T\n", v, v)
}
func test4(v ...int32) {
	printf("test4 %v %T\n", v, v)
}

var a [1024]byte
var s uint = 33
var q int16

// The results of the following examples are given for 64-bit ints.
var i = 1 << s         // 1 has type int
var j int32 = 1 << s   // 1 has type int32; j == 0
var k = uint64(1 << s) // 1 has type uint64; k == 1<<33
var m int = 1.0 << s   // 1.0 has type int; m == 1<<33
var n = 1.0<<s == j    // 1.0 has type int; n == true
var o = 1<<s == 2<<s   // 1 and 2 have type int; o == false
var p = 1<<s == 1<<33  // 1 has type int; p == true
// var u = 1.0<<s                 // illegal: 1.0 has type float64, cannot shift
// var u1 = 1.0<<s != 0           // illegal: 1.0 has type float64, cannot shift
// var u2 = 1<<s != 1.0           // illegal: 1 has type float64, cannot shift
// var v float32 = 1<<s           // illegal: 1 has type float32, cannot shift
var w int64 = 1.0 << 33 // 1.0<<33 is a constant shift expression; w == 1<<33
// var x = a[1.0<<s]              // panics: 1.0 has type int, but 1<<33 overflows array bounds
var x = a[1.0<<(s-30)]
var b = make([]byte, 1.0<<(s-30)) // 1.0 has type int; len(b) == 1<<33
q = 1.0 << (s - 30)

test1(1 << s)
test2(1 << s)
test3(1 << s)
test4(1<<s, 1<<(s-2))

printf("%v %T\n", i, i)
printf("%v %T\n", j, j)
printf("%v %T\n", k, k)
printf("%v %T\n", m, m)
printf("%v %T\n", n, n)
printf("%v %T\n", o, o)
printf("%v %T\n", p, p)
printf("%v %T\n", q, q)
printf("%v %T\n", w, w)
printf("%v %T\n", x, x)
printf("%v %T\n", len(b), b)
```
generate Golang code
```
package main

import fmt "fmt"

var (
	a [1024]uint8
	s uint
	q int16
	i int
	j int32
	k uint64
	m int
	n bool
	o bool
	p bool
	w int64
	x uint8
	b []uint8
)

func main() {
//line ./left_shift.gop:15
	s = uint(33)
//line ./left_shift.gop:19
	i = 1 << s
//line ./left_shift.gop:20
	j = int32(1) << s
//line ./left_shift.gop:21
	k = uint64(uint64(1) << s)
//line ./left_shift.gop:22
	m = 1 << s
//line ./left_shift.gop:23
	n = int32(1)<<s == j
//line ./left_shift.gop:24
	o = 1<<s == 2<<s
//line ./left_shift.gop:25
	p = 1<<s == 8589934592
//line ./left_shift.gop:30
	w = int64(8589934592)
//line ./left_shift.gop:32
	x = a[1<<(s-uint(30))]
//line ./left_shift.gop:33
	b = make([]uint8, 1<<(s-uint(30)))
//line ./left_shift.gop:34
	q = int16(1) << (s - uint(30))
//line ./left_shift.gop:36
	test1(1 << s)
//line ./left_shift.gop:37
	test2(int32(1) << s)
//line ./left_shift.gop:38
	test3(int64(1) << s)
//line ./left_shift.gop:39
	test4(int32(1)<<s, int32(1)<<(s-uint(2)))
//line ./left_shift.gop:41
	fmt.Printf("%v %T\n", i, i)
//line ./left_shift.gop:42
	fmt.Printf("%v %T\n", j, j)
//line ./left_shift.gop:43
	fmt.Printf("%v %T\n", k, k)
//line ./left_shift.gop:44
	fmt.Printf("%v %T\n", m, m)
//line ./left_shift.gop:45
	fmt.Printf("%v %T\n", n, n)
//line ./left_shift.gop:46
	fmt.Printf("%v %T\n", o, o)
//line ./left_shift.gop:47
	fmt.Printf("%v %T\n", p, p)
//line ./left_shift.gop:48
	fmt.Printf("%v %T\n", q, q)
//line ./left_shift.gop:49
	fmt.Printf("%v %T\n", w, w)
//line ./left_shift.gop:50
	fmt.Printf("%v %T\n", x, x)
//line ./left_shift.gop:51
	fmt.Printf("%v %T\n", len(b), b)
}
func test4(_arg_0 ...int32) {
//line ./left_shift.gop:11
	fmt.Printf("test4 %v %T\n", _arg_0, _arg_0)
}
func test1(_arg_0 int) {
//line ./left_shift.gop:2
	fmt.Printf("test1 %v %T\n", _arg_0, _arg_0)
}
func test3(_arg_0 int64) {
//line ./left_shift.gop:8
	fmt.Printf("test3 %v %T\n", _arg_0, _arg_0)
}
func test2(_arg_0 int32) {
//line ./left_shift.gop:5
	fmt.Printf("test2 %v %T\n", _arg_0, _arg_0)
}
```