### PR TITLE
cl: fix op right shift and const op shift

### DIFF
--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -175,7 +175,7 @@ func IsPtrKind(kind reflect.Kind) bool {
 func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(t, b)
-	} else if lsh, ok := v.(*lshValue); ok {
+	} else if lsh, ok := v.(*shiftValue); ok {
 		lsh.checkType(t)
 	} else {
 		iv := v.(iValue)
@@ -203,7 +203,7 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 func checkIntType(v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(exec.TyInt, b)
-	} else if lsh, ok := v.(*lshValue); ok {
+	} else if lsh, ok := v.(*shiftValue); ok {
 		lsh.checkType(exec.TyInt)
 	} else {
 		iv := v.(iValue)

--- a/cl/check_type.go
+++ b/cl/check_type.go
@@ -175,8 +175,8 @@ func IsPtrKind(kind reflect.Kind) bool {
 func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(t, b)
-	} else if lsh, ok := v.(*shiftValue); ok {
-		lsh.checkType(t)
+	} else if shv, ok := v.(*shiftValue); ok {
+		shv.checkType(t)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()
@@ -203,8 +203,8 @@ func checkType(t reflect.Type, v interface{}, b exec.Builder) {
 func checkIntType(v interface{}, b exec.Builder) {
 	if cons, ok := v.(*constVal); ok {
 		cons.bound(exec.TyInt, b)
-	} else if lsh, ok := v.(*shiftValue); ok {
-		lsh.checkType(exec.TyInt)
+	} else if shv, ok := v.(*shiftValue); ok {
+		shv.checkType(exec.TyInt)
 	} else {
 		iv := v.(iValue)
 		n := iv.NumValues()

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -747,23 +747,23 @@ func binaryOpResult(op exec.Operator, x, y interface{}) (exec.Kind, iValue) {
 	kind := vx.Kind()
 	if !isConstBound(kind) {
 		kind = vy.Kind()
-		if xlsh, xok := x.(*shiftValue); xok {
+		if xshv, xok := x.(*shiftValue); xok {
 			var unbound bool
 			if !isConstBound(kind) {
-				if kind != xlsh.Kind() {
+				if kind != xshv.Kind() {
 					unbound = true
 				}
 				if c, ok := y.(*constVal); ok {
 					kind = c.boundKind()
 					c.v = boundConst(c.v, c.boundType())
 					c.kind = kind
-				} else if lsh, ok := y.(*shiftValue); ok && lsh.Kind() == exec.ConstUnboundInt {
+				} else if shv, ok := y.(*shiftValue); ok && shv.Kind() == exec.ConstUnboundInt {
 					kind = exec.Int
-					lsh.bound(exec.TyInt)
+					shv.bound(exec.TyInt)
 				}
 			}
 			if !unbound {
-				xlsh.bound(vy.Type())
+				xshv.bound(vy.Type())
 			}
 		} else if !isConstBound(kind) {
 			log.Panicln("binaryOp: expect x, y aren't const values either.")
@@ -1064,8 +1064,8 @@ func compileIdx(ctx *blockCtx, v ast.Expr, nlast int, kind reflect.Kind) int {
 		}
 		ctx.out.Push(n)
 		return -1
-	} else if lsh, ok := i.(*shiftValue); ok {
-		lsh.bound(exec.TyInt)
+	} else if shv, ok := i.(*shiftValue); ok {
+		shv.bound(exec.TyInt)
 	}
 
 	expr()

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1927,6 +1927,71 @@ func TestTwoValueExpr(t *testing.T) {
 	cltest.Expect(t, clause, "1 3 true\n3 0 false\n")
 }
 
+func TestOpRsh(t *testing.T) {
+	cltest.Expect(t, `
+	var a [1024]byte
+	var s uint = 3
+	// The results of the following examples are given for 64-bit ints.
+	var i = 1024>>s                   // 1 has type int
+	var j int32 = 1024>>s             // 1 has type int32; j == 0
+	var k = uint64(1024>>s)           // 1 has type uint64; k == 1<<33
+	var m int = 1024.0>>s             // 1.0 has type int; m == 1<<33
+	var n = 1024.0>>s == j            // 1.0 has type int; n == true
+	var o = 1024>>s == 2048<<s        // 1 and 2 have type int; o == false
+	var p = 1024>>s == 1024>>3        // 1 has type int; p == true
+	var w int64 = 1024.0>>3           // 1.0<<33 is a constant shift expression; w == 1<<33
+	var x = a[1024.0>>s]              // 1.0 has type int
+	var b = make([]byte, 1024.0>>s)   // 1.0 has type int; len(b) == 1024>>3
+	printf("%T %T %T %T %T %T %T %T %T %T\n",i,j,k,m,n,o,p,w,x,b)
+	`, "int int32 uint64 int bool bool bool int64 uint8 []uint8\n")
+	cltest.Expect(t, `
+	func test1(v int) {
+		printf("%T\n",v)
+	}
+	func test2(v int32) {
+		printf("%T\n",v)
+	}
+	func test3(v int64) {
+		printf("%T\n",v)
+	}
+	func test4(fmt string,v ...int32) {
+		printf(fmt,v)
+	}
+	var s uint = 3
+	test1(1024>>s)
+	test2(1024>>s)
+	test3(1024>>s)
+	test4("%T\n",1024>>s)
+	`, "int\nint32\nint64\n[]int32\n")
+	cltest.Expect(t, `
+	var a int
+	var b int32
+	var c int64
+	var s uint = 3
+	a,b,c = 1024>>s,1024>>s,1024>>s
+	printf("%T %T %T\n",a,b,c)
+	`, "int int32 int64\n")
+	cltest.Expect(t, `
+	var s uint = 3
+	var u = 1024.0<<s
+	println(u)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s uint = 3
+	var u1 = 1024.0>>s != 0
+	println(u1)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s uint = 3
+	var v float32 = 1024>>s
+	println(v)
+	`, "", nil)
+	cltest.Expect(t, `
+	var s = 1.1 >> 3
+	println(s)
+	`, "", "constant 1.1 truncated to integer")
+}
+
 func TestOpLsh(t *testing.T) {
 	cltest.Expect(t, `
 	var a [1024]byte

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1927,6 +1927,27 @@ func TestTwoValueExpr(t *testing.T) {
 	cltest.Expect(t, clause, "1 3 true\n3 0 false\n")
 }
 
+func TestOpShift(t *testing.T) {
+	cltest.Expect(t, `
+	const u uint32 = 3
+	var a = 1 << u
+	var b = 1024 >> u
+	var c = 1.0 << u
+	var d = 1024.0 >> u
+	printf("%v %T\n",a,a)
+	printf("%v %T\n",b,b)
+	printf("%v %T\n",c,c)
+	printf("%v %T\n",d,d)
+	`, "8 int\n128 int\n8 int\n128 int\n")
+	cltest.Expect(t, `
+	var u uint32 = 3
+	var a = 1 << u
+	var b = 1024 >> u
+	printf("%v %T\n",a,a)
+	printf("%v %T\n",b,b)
+	`, "8 int\n128 int\n")
+}
+
 func TestOpRsh(t *testing.T) {
 	cltest.Expect(t, `
 	var a [1024]byte

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1940,12 +1940,16 @@ func TestOpShift(t *testing.T) {
 	printf("%v %T\n",d,d)
 	`, "8 int\n128 int\n8 int\n128 int\n")
 	cltest.Expect(t, `
-	var u uint32 = 3
+	const u uint32 = 3
 	var a = 1 << u
 	var b = 1024 >> u
+	var c int32 = 1.0 << u
+	var d int32 = 1024.0 >> u
 	printf("%v %T\n",a,a)
 	printf("%v %T\n",b,b)
-	`, "8 int\n128 int\n")
+	printf("%v %T\n",c,c)
+	printf("%v %T\n",d,d)
+	`, "8 int\n128 int\n8 int32\n128 int32\n")
 }
 
 func TestOpRsh(t *testing.T) {

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -441,8 +441,8 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 				pushConstVal(ctx.out, cons)
 			}
 		}
-		if lsh, ok := in.(*shiftValue); ok {
-			lsh.bound(typ)
+		if shv, ok := in.(*shiftValue); ok {
+			shv.bound(typ)
 		}
 	}
 	ctx.infer.Ret(1, &goValue{typ})

--- a/cl/goinstr.go
+++ b/cl/goinstr.go
@@ -441,7 +441,7 @@ func compileTypeCast(typ reflect.Type, ctx *blockCtx, v *ast.CallExpr) func() {
 				pushConstVal(ctx.out, cons)
 			}
 		}
-		if lsh, ok := in.(*lshValue); ok {
+		if lsh, ok := in.(*shiftValue); ok {
 			lsh.bound(typ)
 		}
 	}

--- a/cl/value.go
+++ b/cl/value.go
@@ -48,35 +48,35 @@ func isBool(v iValue) bool {
 
 // -----------------------------------------------------------------------------
 
-type lshValue struct {
+type shiftValue struct {
 	x           *constVal
 	r           exec.Reserved
 	fnCheckType func(typ reflect.Type)
 }
 
-func (p *lshValue) checkType(t reflect.Type) {
+func (p *shiftValue) checkType(t reflect.Type) {
 	p.fnCheckType(t)
 }
 
-func (p *lshValue) bound(t reflect.Type) {
+func (p *shiftValue) bound(t reflect.Type) {
 	v := boundConst(p.x.v, t)
 	p.x.v = v
 	p.x.kind = t.Kind()
 }
 
-func (p *lshValue) Kind() iKind {
+func (p *shiftValue) Kind() iKind {
 	return p.x.kind
 }
 
-func (p *lshValue) Type() reflect.Type {
+func (p *shiftValue) Type() reflect.Type {
 	return boundType(p.x)
 }
 
-func (p *lshValue) NumValues() int {
+func (p *shiftValue) NumValues() int {
 	return 1
 }
 
-func (p *lshValue) Value(i int) iValue {
+func (p *shiftValue) Value(i int) iValue {
 	return p
 }
 

--- a/cl/value.go
+++ b/cl/value.go
@@ -369,7 +369,9 @@ func binaryOp(op exec.Operator, x, y *constVal) *constVal {
 	xkind := x.kind
 	ykind := y.kind
 	var kind, kindReal astutil.ConstKind
-	if isConstBound(xkind) {
+	if op == exec.OpLsh || op == exec.OpRsh {
+		kind, kindReal = xkind, realKindOf(xkind)
+	} else if isConstBound(xkind) {
 		kind, kindReal = xkind, xkind
 	} else if isConstBound(ykind) {
 		kind, kindReal = ykind, ykind

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -374,11 +374,11 @@ type Builder interface {
 	// ReservedAsPush sets Reserved as Push(v)
 	ReservedAsPush(r Reserved, v interface{})
 
-	// ReserveOpLsh reserves an instruction.
-	ReserveOpLsh() Reserved
+	// ReserveOpShift reserves an instruction.
+	ReserveOpShift() Reserved
 
-	// ReservedAsOpLsh sets Reserved as OpLsh
-	ReservedAsOpLsh(r Reserved, kind Kind, op Operator)
+	// ReservedAsOpShift sets Reserved as OpLsh/OpRsh
+	ReservedAsOpShift(r Reserved, kind Kind, op Operator)
 
 	// GetPackage returns the Go+ package that the Builder works for.
 	GetPackage() Package

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -488,14 +488,14 @@ func (p *iBuilder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	((*Builder)(p)).ReservedAsPush(r, v)
 }
 
-// ReserveOpLsh reserves an instruction.
-func (p *iBuilder) ReserveOpLsh() exec.Reserved {
+// ReserveOpShift reserves an instruction.
+func (p *iBuilder) ReserveOpShift() exec.Reserved {
 	return ((*Builder)(p)).Reserve()
 }
 
-// ReservedAsOpLsh sets Reserved as GoBuiltin
-func (p *iBuilder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) {
-	((*Builder)(p)).ReservedAsOpLsh(r, kind, op)
+// ReservedAsOpShift sets Reserved as OpLsh/OpRsh
+func (p *iBuilder) ReservedAsOpShift(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	((*Builder)(p)).ReservedAsOpShift(r, kind, op)
 }
 
 // GetPackage returns the Go+ package that the Builder works for.

--- a/exec/bytecode/operator.go
+++ b/exec/bytecode/operator.go
@@ -260,13 +260,13 @@ func (p *Code) builtinOp(kind Kind, op Operator) error {
 	return fmt.Errorf("builtinOp: type %v doesn't support operator %v", kind, op)
 }
 
-func (p *Code) reservedAsOpLsh(index int, kind Kind, op Operator) error {
+func (p *Code) reservedAsOpShift(index int, kind Kind, op Operator) error {
 	i := (int(kind) << bitsOperator) | int(op)
 	if fn := builtinOps[i]; fn != nil {
 		p.data[index] = (opBuiltinOp << bitsOpShift) | uint32(i)
 		return nil
 	}
-	return fmt.Errorf("reservedAsOpLsh: type %v doesn't support operator %v", kind, op)
+	return fmt.Errorf("ReservedAsOpShift: type %v doesn't support operator %v", kind, op)
 }
 
 // BuiltinOp instr
@@ -279,10 +279,10 @@ func (p *Builder) BuiltinOp(kind Kind, op Operator) *Builder {
 	return p
 }
 
-// ReservedAsOpLsh instr
-func (p *Builder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) *Builder {
-	log.Debug("ReservedAsOpLsh:", kind, op)
-	err := p.code.reservedAsOpLsh(int(r), kind, op)
+// ReservedAsOpShift sets Reserved as OpLsh/OpRsh
+func (p *Builder) ReservedAsOpShift(r exec.Reserved, kind exec.Kind, op exec.Operator) *Builder {
+	log.Debug("ReservedAsOpShift:", kind, op)
+	err := p.code.reservedAsOpShift(int(r), kind, op)
 	if err != nil {
 		panic(err)
 	}

--- a/exec/golang/builder.go
+++ b/exec/golang/builder.go
@@ -368,15 +368,15 @@ func (p *Builder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	p.reserveds[r].(*printer.ReservedExpr).Expr = Const(p, v)
 }
 
-type reserveLsh struct {
+type reservedShift struct {
 	expr *printer.ReservedExpr
 	x    ast.Expr
 	y    ast.Expr
 }
 
-// ReserveOpLsh reserves an instruction.
-func (p *Builder) ReserveOpLsh() exec.Reserved {
-	r := &reserveLsh{}
+// ReserveOpShift reserves an instruction.
+func (p *Builder) ReserveOpShift() exec.Reserved {
+	r := &reservedShift{}
 	r.expr = new(printer.ReservedExpr)
 	r.y = p.rhs.Pop().(ast.Expr)
 	r.x = p.rhs.Pop().(ast.Expr)
@@ -386,10 +386,10 @@ func (p *Builder) ReserveOpLsh() exec.Reserved {
 	return exec.Reserved(idx)
 }
 
-// ReservedAsOpLsh sets Reserved as GoBuiltin
-func (p *Builder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+// ReservedAsOpShift sets Reserved as OpLsh/OpRsh
+func (p *Builder) ReservedAsOpShift(r exec.Reserved, kind exec.Kind, op exec.Operator) {
 	tok := opTokens[op]
-	rsh := p.reserveds[r].(*reserveLsh)
+	rsh := p.reserveds[r].(*reservedShift)
 	rsh.expr.Expr = &ast.BinaryExpr{Op: tok, X: rsh.x, Y: rsh.y}
 }
 

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -505,14 +505,14 @@ func (p *iBuilder) ReservedAsPush(r exec.Reserved, v interface{}) {
 	((*Builder)(p)).ReservedAsPush(r, v)
 }
 
-// ReserveOpLsh reserves an instruction.
-func (p *iBuilder) ReserveOpLsh() exec.Reserved {
-	return ((*Builder)(p)).ReserveOpLsh()
+// ReserveOpShift reserves an instruction.
+func (p *iBuilder) ReserveOpShift() exec.Reserved {
+	return ((*Builder)(p)).ReserveOpShift()
 }
 
-// ReservedAsOpLsh sets Reserved as GoBuiltin
-func (p *iBuilder) ReservedAsOpLsh(r exec.Reserved, kind exec.Kind, op exec.Operator) {
-	((*Builder)(p)).ReservedAsOpLsh(r, kind, op)
+// ReservedAsOpShift sets Reserved as OpLsh/OpRsh
+func (p *iBuilder) ReservedAsOpShift(r exec.Reserved, kind exec.Kind, op exec.Operator) {
+	((*Builder)(p)).ReservedAsOpShift(r, kind, op)
 }
 
 // GetPackage returns the Go+ package that the Builder works for.


### PR DESCRIPTION
fix #689 

https://golang.google.cn/ref/spec#Operators
* fix op right shift check type
* fix const op shift check type

Go+ code
```
const u uint32 = 3
var v uint32 = 3

var a = 1 << u
var b = 1024 >> u
var c = 1.0 << u
var d = 1024.0 >> u
var e = 1 << v
var f = 1024 >> v
var i int32 = 1.0 << v
var j int32 = 1024.0 >> v

printf("%v %T\n",a,a)
printf("%v %T\n",b,b)
printf("%v %T\n",c,c)
printf("%v %T\n",d,d)
printf("%v %T\n",a,a)
printf("%v %T\n",b,b)
printf("%v %T\n",e,e)
printf("%v %T\n",f,f)
printf("%v %T\n",i,i)
printf("%v %T\n",j,j)
```
generate Golang code
```
package main

import fmt "fmt"

var (
	v uint32
	a int
	b int
	c int
	d int
	e int
	f int
	i int32
	j int32
)

func main() { 
//line ./main.gop:3
	v = uint32(3)
//line ./main.gop:5
	a = 8
//line ./main.gop:6
	b = 128
//line ./main.gop:7
	c = 8
//line ./main.gop:8
	d = 128
//line ./main.gop:9
	e = 1 << v
//line ./main.gop:10
	f = 1024 >> v
//line ./main.gop:11
	i = int32(1) << v
//line ./main.gop:12
	j = int32(1024) >> v
//line ./main.gop:14
	fmt.Printf("%v %T\n", a, a)
//line ./main.gop:15
	fmt.Printf("%v %T\n", b, b)
//line ./main.gop:16
	fmt.Printf("%v %T\n", c, c)
//line ./main.gop:17
	fmt.Printf("%v %T\n", d, d)
//line ./main.gop:18
	fmt.Printf("%v %T\n", a, a)
//line ./main.gop:19
	fmt.Printf("%v %T\n", b, b)
//line ./main.gop:20
	fmt.Printf("%v %T\n", e, e)
//line ./main.gop:21
	fmt.Printf("%v %T\n", f, f)
//line ./main.gop:22
	fmt.Printf("%v %T\n", i, i)
//line ./main.gop:23
	fmt.Printf("%v %T\n", j, j)
}
```