### PR TITLE
redeclare variables in a short variable declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - "1.14"
+  - "1.15"
+  - "1.16"
 install:
   - go get golang.org/x/tools/cmd/goimports
   - go get github.com/golangci/gocyclo/cmd/gocyclo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 go:
   - "1.14"
-  - "1.15"
-  - "1.16"
 install:
   - go get golang.org/x/tools/cmd/goimports
   - go get github.com/golangci/gocyclo/cmd/gocyclo

--- a/cl/context.go
+++ b/cl/context.go
@@ -190,7 +190,6 @@ type blockCtx struct {
 	fieldStructType reflect.Type
 	fieldIndex      []int
 	fieldExprX      func()
-	underscore      int
 	newIdentVar     int
 }
 

--- a/cl/context.go
+++ b/cl/context.go
@@ -191,6 +191,7 @@ type blockCtx struct {
 	fieldIndex      []int
 	fieldExprX      func()
 	underscore      int
+	newIdentVar     int
 }
 
 // function block ctx

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -116,8 +116,8 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 		addr, err = ctx.findVar(name)
 		if mode == lhsDefine {
 			addr, err = ctx.getCtxVar(name)
-			if addr != nil {
-				log.Panicf("compileIdentLHS failed: %s redeclared in this block\n", name)
+			if addr == nil {
+				ctx.newIdentVar++
 			}
 		}
 		if err == nil {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -108,7 +108,6 @@ func compileIdentLHS(ctx *blockCtx, name string, mode compileMode) {
 	in := ctx.infer.Get(-1)
 	var addr iVar
 	if name == "_" {
-		ctx.underscore++
 		typ := boundType(in.(iValue))
 		addr = ctx.insertVar(name, typ)
 	} else {

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -651,11 +651,21 @@ func compileAssignStmt(ctx *blockCtx, expr *ast.AssignStmt) {
 	}
 	count := len(expr.Lhs)
 	ctx.underscore = 0
+	ctx.newIdentVar = 0
 	for i := len(expr.Lhs) - 1; i >= 0; i-- {
 		compileExprLHS(ctx, expr.Lhs[i], expr.Tok)
 	}
-	if ctx.underscore == count && expr.Tok == token.DEFINE {
-		log.Panicln("no new variables on left side of :=")
+	if expr.Tok == token.DEFINE {
+		if ctx.underscore == count {
+			log.Panicln("no new variables on left side of :=")
+		}
+		if ctx.newIdentVar == 0 {
+			if count == 1 {
+				log.Panicf("compileIdentLHS failed: %s redeclared in this block\n", expr.Lhs[0])
+			} else {
+				log.Panicln("no new variables on left side of :=")
+			}
+		}
 	}
 }
 

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -649,23 +649,12 @@ func compileAssignStmt(ctx *blockCtx, expr *ast.AssignStmt) {
 	if ctx.infer.Len() != len(expr.Lhs) {
 		log.Panicln("compileAssignStmt: assign statement has mismatched variables count -", ctx.infer.Len())
 	}
-	count := len(expr.Lhs)
-	ctx.underscore = 0
 	ctx.newIdentVar = 0
 	for i := len(expr.Lhs) - 1; i >= 0; i-- {
 		compileExprLHS(ctx, expr.Lhs[i], expr.Tok)
 	}
-	if expr.Tok == token.DEFINE {
-		if ctx.underscore == count {
-			log.Panicln("no new variables on left side of :=")
-		}
-		if ctx.newIdentVar == 0 {
-			if count == 1 {
-				log.Panicf("compileIdentLHS failed: %s redeclared in this block\n", expr.Lhs[0])
-			} else {
-				log.Panicln("no new variables on left side of :=")
-			}
-		}
+	if ctx.newIdentVar == 0 && expr.Tok == token.DEFINE {
+		log.Panicln("no new variables on left side of :=")
 	}
 }
 

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1475,6 +1475,16 @@ func TestGo(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 var testVarScopeClauses = map[string]testData{
+	"redeclared_variable_#issue640": {`
+						a:=0
+						b:=0
+						a,b:=1,1
+						`, "", true},
+	"redeclared_variable_#issue640_2": {`
+						a:=0
+						a,b:=1,2
+						println(a,b)
+						`, "1 2\n", false},
 	"variable_redefinition_#issue304": {`
 						a := []float64{1, 2, 3.4}
 						println(a)

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -1485,6 +1485,14 @@ var testVarScopeClauses = map[string]testData{
 						a,b:=1,2
 						println(a,b)
 						`, "1 2\n", false},
+	"redeclared_variable_#issue640_3": {`
+						a:=0
+						a,_:=1,1
+						`, "", true},
+	"redeclared_variable_#issue640_4": {`
+						_,b:=1,2
+						println(b)
+						`, "2\n", false},
 	"variable_redefinition_#issue304": {`
 						a := []float64{1, 2, 3.4}
 						println(a)


### PR DESCRIPTION
#640 
```
a:=0
a,b:=1,2
println(a,b)
```