### PR TITLE
implement recover instr for exec/bytecode

### DIFF
--- a/exec/bytecode/code.go
+++ b/exec/bytecode/code.go
@@ -239,7 +239,6 @@ type Code struct {
 	structs    []StructInfo
 	errWraps   []errWrap
 	varManager
-	*execInfo
 }
 
 type panicInfo struct {
@@ -257,7 +256,7 @@ type execInfo struct {
 
 // NewCode returns a new Code object.
 func NewCode() *Code {
-	return &Code{data: make([]Instr, 0, 64), execInfo: &execInfo{}}
+	return &Code{data: make([]Instr, 0, 64)}
 }
 
 // Len returns code length.

--- a/exec/bytecode/code.go
+++ b/exec/bytecode/code.go
@@ -239,11 +239,25 @@ type Code struct {
 	structs    []StructInfo
 	errWraps   []errWrap
 	varManager
+	*execInfo
+}
+
+type panicInfo struct {
+	v      interface{}
+	ip     int
+	depth  int
+	name   string
+	parent *panicInfo
+}
+
+type execInfo struct {
+	depth  int
+	panics *panicInfo
 }
 
 // NewCode returns a new Code object.
 func NewCode() *Code {
-	return &Code{data: make([]Instr, 0, 64)}
+	return &Code{data: make([]Instr, 0, 64), execInfo: &execInfo{}}
 }
 
 // Len returns code length.

--- a/exec/bytecode/context.go
+++ b/exec/bytecode/context.go
@@ -17,8 +17,6 @@
 package bytecode
 
 import (
-	"fmt"
-	"os"
 	"reflect"
 	"time"
 
@@ -143,11 +141,13 @@ func (ctx *Context) getScope(local bool) *varScope {
 func (ctx *Context) Run() {
 	defer func() {
 		if v := recover(); v != nil {
-			fmt.Println("panic:", ctx.panics.v)
-			os.Exit(2)
+			ctx.panics = &panicInfo{v, ctx.ip}
+		}
+		ctx.execDefers()
+		if ctx.panics != nil {
+			panic(ctx.panics.v)
 		}
 	}()
-	defer ctx.execDefers()
 	ctx.Exec(0, ctx.code.Len())
 }
 

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -65,7 +65,7 @@ func makeClosure(i Instr, p *Context) Closure {
 	} else {
 		fun = p.code.funs[idx]
 	}
-	return Closure{fun: fun, parent: p.getScope(fun.nestDepth > 1)}
+	return Closure{fun: fun, parent: p.getScope(fun.nestDepth > 1), exec: p.exec}
 }
 
 func execGoClosure(i Instr, p *Context) {
@@ -150,11 +150,13 @@ type Closure struct {
 	fun    *FuncInfo
 	recv   interface{}
 	parent *varScope
+	exec   *execInfo
 }
 
 // Call calls a closure.
 func (p *Closure) Call(in []reflect.Value) (out []reflect.Value) {
 	ctx := NewContext(p.fun.Pkg.code)
+	ctx.exec = p.exec
 	for _, v := range in {
 		ctx.Push(v.Interface())
 	}
@@ -296,21 +298,21 @@ func (p *FuncInfo) Type() reflect.Type {
 
 func (p *FuncInfo) execFunc(ctx *Context) {
 	p._execFunc(ctx)
-	if ctx.code.panics != nil && ctx.code.panics.depth >= ctx.code.depth {
-		panic(ctx.code.panics.v)
+	if ctx.exec.panics != nil && ctx.exec.panics.depth >= ctx.exec.depth {
+		panic(ctx.exec.panics.v)
 	}
 }
 
 func (p *FuncInfo) _execFunc(ctx *Context) {
 	oldDefers := ctx.defers
 	ctx.defers = nil
-	ctx.code.depth++
-	depth := ctx.code.depth
+	ctx.exec.depth++
+	depth := ctx.exec.depth
 	defer func() {
-		ctx.code.depth--
-		if ctx.code.panics == nil || ctx.code.panics.depth >= ctx.code.depth {
+		ctx.exec.depth--
+		if ctx.exec.panics == nil || ctx.exec.panics.depth >= ctx.exec.depth {
 			if v := recover(); v != nil {
-				ctx.code.panics = &panicInfo{v, ctx.ip - 1, depth, p.name, ctx.code.panics}
+				ctx.exec.panics = &panicInfo{v, ctx.ip - 1, depth, p.name, ctx.exec.panics}
 			}
 		}
 		ctx.execDefers()

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -298,8 +298,14 @@ func (p *FuncInfo) execFunc(ctx *Context) {
 	oldDefers := ctx.defers
 	ctx.defers = nil
 	defer func() {
+		if v := recover(); v != nil {
+			ctx.panics = &panicInfo{v, ctx.ip}
+		}
 		ctx.execDefers()
 		ctx.defers = oldDefers
+		if ctx.panics != nil {
+			panic(ctx.panics.v)
+		}
 	}()
 	ctx.Exec(p.funEntry, p.funEnd)
 	if ctx.ip == ipReturnN { // TODO: optimize

--- a/exec/bytecode/func.go
+++ b/exec/bytecode/func.go
@@ -305,11 +305,11 @@ func (p *FuncInfo) _execFunc(ctx *Context) {
 	oldDefers := ctx.defers
 	ctx.defers = nil
 	defer func() {
-		if ctx.panics == nil || ctx.panics.depth >= p.nestDepth {
-			if v := recover(); v != nil {
-				ctx.panics = &panicInfo{v, ctx.ip, p.nestDepth}
-			}
+		//if ctx.panics == nil { //}|| ctx.panics.depth >= p.nestDepth {
+		if v := recover(); v != nil {
+			ctx.panics = &panicInfo{v, ctx.ip - 1, p.nestDepth, p.name, ctx.panics}
 		}
+		//}
 		ctx.execDefers()
 		ctx.defers = oldDefers
 	}()

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -87,6 +87,8 @@ const (
 	GobImag = exec.GobImag
 	// GobClose - close: 8
 	GobClose = exec.GobClose
+	// GobRecover - recover: 9
+	GobRecover = exec.GobRecover
 )
 
 // -----------------------------------------------------------------------------
@@ -161,6 +163,9 @@ func execGoBuiltin(i Instr, p *Context) {
 	case GobClose:
 		v := reflect.ValueOf(p.Pop())
 		v.Close()
+	case GobRecover:
+		p.Push(p.panics.v)
+		p.panics = nil
 	default:
 		log.Panicln("execGoBuiltin: todo -", op)
 	}

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -164,9 +164,9 @@ func execGoBuiltin(i Instr, p *Context) {
 		v := reflect.ValueOf(p.Pop())
 		v.Close()
 	case GobRecover:
-		if p.panics != nil {
-			p.Push(p.panics.v)
-			p.panics = nil
+		if p.code.panics != nil && p.code.depth == p.code.panics.depth {
+			p.Push(p.code.panics.v)
+			p.code.panics = nil
 		} else {
 			p.Push(nil)
 		}

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -164,9 +164,9 @@ func execGoBuiltin(i Instr, p *Context) {
 		v := reflect.ValueOf(p.Pop())
 		v.Close()
 	case GobRecover:
-		if p.code.panics != nil && p.code.depth == p.code.panics.depth {
-			p.Push(p.code.panics.v)
-			p.code.panics = nil
+		if p.exec.panics != nil && p.exec.depth == p.exec.panics.depth {
+			p.Push(p.exec.panics.v)
+			p.exec.panics = nil
 		} else {
 			p.Push(nil)
 		}

--- a/exec/bytecode/var.go
+++ b/exec/bytecode/var.go
@@ -164,8 +164,12 @@ func execGoBuiltin(i Instr, p *Context) {
 		v := reflect.ValueOf(p.Pop())
 		v.Close()
 	case GobRecover:
-		p.Push(p.panics.v)
-		p.panics = nil
+		if p.panics != nil {
+			p.Push(p.panics.v)
+			p.panics = nil
+		} else {
+			p.Push(nil)
+		}
 	default:
 		log.Panicln("execGoBuiltin: todo -", op)
 	}

--- a/exec/golang/testdata/35.recover/recover.gop
+++ b/exec/golang/testdata/35.recover/recover.gop
@@ -9,7 +9,18 @@ func protect(g func()) {
 	g()
 }
 
+defer func() {
+	if v := recover(); v != nil {
+		println("recover", v)
+	}
+	if v := recover(); v != nil {
+		println("error", v)
+	}
+}()
+
 protect(func() {
 	i := 0
 	println(1 / i)
 })
+
+panic("hello")

--- a/exec/golang/testdata/35.recover/recover.gop
+++ b/exec/golang/testdata/35.recover/recover.gop
@@ -1,0 +1,15 @@
+func protect(g func()) {
+	defer func() {
+		println("done") // Println executes normally even if there is a panic
+		if x := recover(); x != nil {
+			println("run time panic:", x)
+		}
+	}()
+	println("start")
+	g()
+}
+
+protect(func() {
+	i := 0
+	println(1 / i)
+})


### PR DESCRIPTION
Go+ code

**Not ready**

```
func protect(g func()) {
	defer func() {
		println("done") // Println executes normally even if there is a panic
		if x := recover(); x != nil {
			println("run time panic:", x)
		}
	}()
	println("start")
	g()
}

protect(func() {
	i := 0
	println(1 / i)
})
```
---- output ----
```
start
done
run time panic: runtime error: integer divide by zero
```