### PR TITLE
golang: fix #712, Zero func

### DIFF
--- a/exec/golang/expr.go
+++ b/exec/golang/expr.go
@@ -645,17 +645,16 @@ func (p *Builder) Zero(typ reflect.Type) *Builder {
 // Zero instr
 func Zero(p *Builder, typ reflect.Type) ast.Expr {
 	kind := typ.Kind()
-	if kind == reflect.String {
-		return StringConst("")
-	}
-	if kind >= reflect.Int && kind <= reflect.Complex128 {
-		return IntConst(0)
-	}
 	if kind == reflect.Bool {
 		return Ident("false")
+	} else if kind == reflect.String {
+		return StringConst("")
+	} else if kind >= reflect.Int && kind <= reflect.Complex128 {
+		return IntConst(0)
+	} else if kind == reflect.Struct || kind == reflect.Array {
+		return &ast.CompositeLit{Type: Type(p, typ)}
 	}
-	log.Panicln("Zero: unknown -", typ)
-	return nil
+	return Ident("nil")
 }
 
 // GoBuiltin instr

--- a/exec/golang/testdata/35.zero/zero.gop
+++ b/exec/golang/testdata/35.zero/zero.gop
@@ -1,0 +1,57 @@
+type T struct {
+	X int
+	Y int
+}
+
+println([]bool{
+	0: true,
+	2: false,
+})
+println([]int{
+	0: 100,
+	2: 200,
+})
+println([]uint{
+	0: 100,
+	2: 200,
+})
+println([]float32{
+	0: 100,
+	2: 200,
+})
+println([]float64{
+	0: 100,
+	2: 200,
+})
+println([]complex64{
+	0: 100 + 1i,
+	2: 200 + 1i,
+})
+println([]complex128{
+	0: 100 + 1i,
+	2: 200 + 1i,
+})
+println([]string{
+	0: "hello",
+	2: "world",
+})
+println([]T{
+	0: T{1, 2},
+	2: T{3, 4},
+})
+println([]*T{
+	0: &T{1, 2},
+	2: &T{3, 4},
+}[1])
+println([]func(){
+	0: func() {},
+	2: func() {},
+}[1])
+println([]chan int{
+	0: make(chan int),
+	2: make(chan int),
+}[1])
+println([]interface{}{
+	0: 1,
+	2: "world",
+}[1])


### PR DESCRIPTION
fix #712, golang zero func

Go+ code
```
type T struct {
	X int
	Y int
}
println([]T{
	0: T{1, 2},
	2: T{3, 4},
})
println([]*T{
	0: &T{1, 2},
	2: &T{3, 4},
}[1])
println([]func(){
	0: func() {},
	2: func() {},
}[1])
println([]chan int{
	0: make(chan int),
	2: make(chan int),
}[1])
println([]interface{}{
	0: 1,
	2: "world",
}[1])
```
generate Golang code
```
package main

import fmt "fmt"

type T struct {
	X int
	Y int
}

func main() { 
//line ./main.gop:6
	fmt.Println([]T{T{X: 1, Y: 2}, T{}, T{X: 3, Y: 4}})
//line ./main.gop:10
	fmt.Println([]*T{&T{X: 1, Y: 2}, nil, &T{X: 3, Y: 4}}[1])
//line ./main.gop:14
	fmt.Println([]func(){func() {
	}, nil, func() {
	}}[1])
//line ./main.gop:18
	fmt.Println([]chan int{make(chan int), nil, make(chan int)}[1])
//line ./main.gop:22
	fmt.Println([]interface {
	}{1, nil, "world"}[1])
}
```