### PR TITLE
cl: fix #711, compileCompositeLit missing type

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -327,6 +327,9 @@ func compileCompositeLit(ctx *blockCtx, v *ast.CompositeLit) func() {
 			typElem := typSlice.Elem()
 			for _, elt := range elts {
 				if elt != nil {
+					if c, ok := elt.(*ast.CompositeLit); ok && c.Type == nil {
+						c.Type = v.Type.(*ast.ArrayType).Elt
+					}
 					compileExpr(ctx, elt)()
 					checkType(typElem, ctx.infer.Pop(), ctx.out)
 				} else {
@@ -344,8 +347,14 @@ func compileCompositeLit(ctx *blockCtx, v *ast.CompositeLit) func() {
 			for _, elt := range v.Elts {
 				switch e := elt.(type) {
 				case *ast.KeyValueExpr:
+					if c, ok := e.Key.(*ast.CompositeLit); ok && c.Type == nil {
+						c.Type = v.Type.(*ast.MapType).Key
+					}
 					compileExpr(ctx, e.Key)()
 					checkType(typKey, ctx.infer.Pop(), ctx.out)
+					if c, ok := e.Value.(*ast.CompositeLit); ok && c.Type == nil {
+						c.Type = v.Type.(*ast.MapType).Value
+					}
 					compileExpr(ctx, e.Value)()
 					checkType(typVal, ctx.infer.Pop(), ctx.out)
 				default:

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -1309,6 +1309,30 @@ func TestStruct2(t *testing.T) {
 	testScripts(t, "TestStruct", testStructClauses)
 }
 
+func TestCompositeLit(t *testing.T) {
+	cltest.Expect(t, `
+	type T struct {
+		X int
+		Y int
+	}
+	ar := []T{
+		{1,2},
+		{3,4},
+	}
+	ar1 := [2]T{
+		{1,2},
+		{3,4},
+	}
+	m := map[T]T{
+		{1,2}:{10,20},
+		{3,4}:{30,40},
+	}
+	println(ar)
+	println(ar1)
+	println(m)
+	`, "[{1 2} {3 4}]\n[{1 2} {3 4}]\nmap[{1 2}:{10 20} {3 4}:{30 40}]\n")
+}
+
 // -----------------------------------------------------------------------------
 var testMethodClauses = map[string]testData{
 	"method set": {`


### PR DESCRIPTION
fix #711 ,  compileCompositeLit check missing type for struct.

Go+ code
```
type T struct {
	X int
	Y int
}
ar := []T{
	{1,2},
	{3,4},
}
ar1 := [2]T{
	{1,2},
	{3,4},
}
m := map[T]T{
	{1,2}:{10,20},
	{3,4}:{30,40},
}
println(ar)
println(ar1)
println(m)
```
generate Golang code
```
package main

import fmt "fmt"

type T struct {
	X int
	Y int
}

var (
	ar  []T
	ar1 [2]T
	m   map[T]T
)

func main() { 
//line ./main.gop:6
	ar = []T{T{X: 1, Y: 2}, T{X: 3, Y: 4}}
//line ./main.gop:10
	ar1 = [2]T{T{X: 1, Y: 2}, T{X: 3, Y: 4}}
//line ./main.gop:14
	m = map[T]T{T{X: 1, Y: 2}: T{X: 10, Y: 20}, T{X: 3, Y: 4}: T{X: 30, Y: 40}}
//line ./main.gop:18
	fmt.Println(ar)
//line ./main.gop:19
	fmt.Println(ar1)
//line ./main.gop:20
	fmt.Println(m)
}
```