### PR TITLE
cl: fix #733, call init func

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -169,6 +169,10 @@ func NewPackageEx(out exec.Builder, pkg *ast.Package, fset *token.FileSet, act P
 	for _, f := range pkg.Files {
 		loadFile(ctx, f, imports)
 	}
+	for i := 0; i < len(ctx.inits); i++ {
+		out.CallFunc(ctx.inits[i].Get(), 0)
+		ctx.use(ctx.inits[len(ctx.inits)-1-i])
+	}
 	switch act {
 	case PkgActClAll:
 		for _, sym := range ctx.syms {
@@ -183,10 +187,6 @@ func NewPackageEx(out exec.Builder, pkg *ast.Package, fset *token.FileSet, act P
 	case PkgActClMain:
 		if pkg.Name != "main" {
 			return nil, ErrNotAMainPackage
-		}
-		for i := 0; i < len(ctx.inits); i++ {
-			out.CallFunc(ctx.inits[i].Get(), 0)
-			ctx.use(ctx.inits[len(ctx.inits)-1-i])
 		}
 		entry, err := ctx.findFunc("main")
 		if err != nil {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -184,6 +184,10 @@ func NewPackageEx(out exec.Builder, pkg *ast.Package, fset *token.FileSet, act P
 		if pkg.Name != "main" {
 			return nil, ErrNotAMainPackage
 		}
+		for i := 0; i < len(ctx.inits); i++ {
+			out.CallFunc(ctx.inits[i].Get(), 0)
+			ctx.use(ctx.inits[len(ctx.inits)-1-i])
+		}
 		entry, err := ctx.findFunc("main")
 		if err != nil {
 			if err == ErrNotFound {
@@ -415,8 +419,6 @@ func loadFunc(ctx *blockCtx, d *ast.FuncDecl, isUnnamed bool) {
 		funCtx.noExecCtx = isUnnamed
 		funCtx.funcCtx = newFuncCtx(nil)
 		ctx.insertMethod(recv, name, d, funCtx)
-	} else if name == "init" {
-		log.Panicln("loadFunc TODO: init")
 	} else {
 		funCtx := newExecBlockCtx(ctx)
 		funCtx.noExecCtx = isUnnamed

--- a/cl/context.go
+++ b/cl/context.go
@@ -36,6 +36,7 @@ type pkgCtx struct {
 	builtin exec.GoPackage
 	out     exec.Builder
 	usedfns []*funcDecl
+	inits   []*funcDecl
 	types   map[reflect.Type]*typeDecl
 	pkg     *ast.Package
 	fset    *token.FileSet
@@ -182,7 +183,6 @@ type blockCtx struct {
 	file            *fileCtx
 	parent          *blockCtx
 	syms            map[string]iSymbol
-	inits           []*funcDecl
 	noExecCtx       bool
 	takeAddr        bool
 	indirect        bool

--- a/cl/context.go
+++ b/cl/context.go
@@ -182,6 +182,7 @@ type blockCtx struct {
 	file            *fileCtx
 	parent          *blockCtx
 	syms            map[string]iSymbol
+	inits           []*funcDecl
 	noExecCtx       bool
 	takeAddr        bool
 	indirect        bool
@@ -388,6 +389,10 @@ func (p *blockCtx) insertVar(name string, typ reflect.Type, inferOnly ...bool) *
 }
 
 func (p *blockCtx) insertFunc(name string, fun *funcDecl) {
+	if name == "init" {
+		p.inits = append(p.inits, fun)
+		return
+	}
 	if p.exists(name) {
 		log.Panicln("insertFunc failed: symbol exists -", name)
 	}

--- a/cl/expr_test.go
+++ b/cl/expr_test.go
@@ -2155,3 +2155,15 @@ func TestBadUnsafe(t *testing.T) {
 	println(v)
 	`, "", "invalid expression unsafe.Offsetof(1)")
 }
+
+func TestInit(t *testing.T) {
+	cltest.Expect(t, `
+	func init() {
+		println("init1")
+	}
+	func init() {
+		println("init2")
+	}
+	println("main")
+	`, "init1\ninit2\nmain\n")
+}


### PR DESCRIPTION
fix #733, call init func.

Go+ code
```
package main
func init() {
	println("init1")
}
func init() {
	println("init2")
}
println("hello")
```

generate Golang code
```
package main

import fmt "fmt"

func main() { 
//line ./main.gop:9
	fmt.Println("hello")
}
func init() { 
//line ./main.gop:4
	fmt.Println("init1")
}
func init() { 
//line ./main.gop:7
	fmt.Println("init2")
}
```