### PR TITLE
cl: fix #739, compileBlockStmtWith use block scope

### DIFF
--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -45,9 +45,11 @@ func compileNewBlock(ctx *blockCtx, block *ast.BlockStmt) {
 
 func compileBodyWith(ctx *blockCtx, body []ast.Stmt) {
 	ctxWith := newNormBlockCtx(ctx)
+	ctx.out.DefineBlock()
 	for _, stmt := range body {
 		compileStmt(ctxWith, stmt)
 	}
+	ctx.out.EndBlock()
 }
 
 func compileStmt(ctx *blockCtx, stmt ast.Stmt) {

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -28,7 +28,9 @@ import (
 // -----------------------------------------------------------------------------
 
 func compileBlockStmtWith(ctx *blockCtx, body *ast.BlockStmt) {
+	ctx.out.DefineBlock()
 	compileBodyWith(ctx, body.List)
+	ctx.out.EndBlock()
 }
 
 func compileBlockStmtWithout(ctx *blockCtx, body *ast.BlockStmt) {
@@ -38,18 +40,14 @@ func compileBlockStmtWithout(ctx *blockCtx, body *ast.BlockStmt) {
 }
 
 func compileNewBlock(ctx *blockCtx, block *ast.BlockStmt) {
-	ctx.out.DefineBlock()
 	compileBlockStmtWith(ctx, block)
-	ctx.out.EndBlock()
 }
 
 func compileBodyWith(ctx *blockCtx, body []ast.Stmt) {
 	ctxWith := newNormBlockCtx(ctx)
-	ctx.out.DefineBlock()
 	for _, stmt := range body {
 		compileStmt(ctxWith, stmt)
 	}
-	ctx.out.EndBlock()
 }
 
 func compileStmt(ctx *blockCtx, stmt ast.Stmt) {
@@ -457,7 +455,7 @@ func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 	}
 	if defaultBody != nil {
 		checkFinalFallthrough(defaultBody)
-		compileBodyWith(ctxSw, defaultBody)
+		compileBlockStmtWith(ctxSw, &ast.BlockStmt{List: defaultBody})
 		if hasCaseClause {
 			out.Jmp(done)
 		}
@@ -486,11 +484,11 @@ func compileCaseClause(c *ast.CaseClause, ctxSw *blockCtx, done exec.Label, next
 		fallNext = ok && bs.Tok == token.FALLTHROUGH
 	}
 	if fallNext {
-		compileBodyWith(ctxSw, c.Body[0:len(c.Body)-1])
+		compileBlockStmtWith(ctxSw, &ast.BlockStmt{List: c.Body[0 : len(c.Body)-1]})
 		withoutCheck = ctxSw.NewLabel("")
 		ctxSw.out.Jmp(withoutCheck)
 	} else {
-		compileBodyWith(ctxSw, c.Body)
+		compileBlockStmtWith(ctxSw, &ast.BlockStmt{List: c.Body})
 		ctxSw.out.Jmp(done)
 	}
 	ctxSw.out.Label(next)


### PR DESCRIPTION
fix #739 compileBlockStmtWith use block scope, `  []stmt =>  { []stmt }  `

Go+ code
```
if true {
	a := 10
	println(a)
}
```

before gen code var a to global
```
package main

import fmt "fmt"

var a int

func main() { 
//line ./main.gop:2
	if !true {
		goto _gop_1
	}
//line ./main.gop:3
	a = 10
//line ./main.gop:4
	fmt.Println(a)
//line ./main.gop:2
	goto _gop_1
_gop_1:
}
```

after this PR to code var a to block local scope
```
package main

import fmt "fmt"

func main() { 
//line ./main.gop:2
	if !true {
		goto _gop_1
	}
	{
		var a int
//line ./main.gop:3
		a = 10
//line ./main.gop:4
		fmt.Println(a)
	}
//line ./main.gop:2
	goto _gop_1
_gop_1:
}

```
