### PR TITLE
load type first

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2326,3 +2326,33 @@ func newRepo() Repo {
 `, "")
 	}
 }
+
+func TestLoadType(t *testing.T) {
+	gopClTest(t, `
+package main
+
+func main() {
+	verifyType()
+}
+
+type T int
+
+func verifyType() {
+	t := T(100)
+	println(t)
+}
+`, `package main
+
+import fmt "fmt"
+
+type T int
+
+func main() {
+	verifyType()
+}
+func verifyType() {
+	t := T(100)
+	fmt.Println(t)
+}
+`)
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2302,6 +2302,13 @@ import (
 	testing "testing"
 )
 
+type Repo struct {
+	Title string
+}
+type Result struct {
+	Repo Repo
+}
+
 func TestNew(t *testing.T) {
 	ret := New()
 	expected := Result{}
@@ -2309,20 +2316,10 @@ func TestNew(t *testing.T) {
 		t.Fatal("Test failed:", ret, expected)
 	}
 }
-
-type Result struct {
-	Repo Repo
-}
-
 func New() Result {
 	repo := newRepo()
 	return Result{Repo: repo}
 }
-
-type Repo struct {
-	Title string
-}
-
 func newRepo() Repo {
 	return Repo{Title: "Hi"}
 }


### PR DESCRIPTION
loadFile split to loadType/loadSymbol, load type priority.

Go+ code
```
package main

func main() {
	verifyType()
}

type T int

func verifyType() {
	t := T(100)
	println(t)
}
```
build to go code, load type priority load symbol
```
package main

import fmt "fmt"

type T int

func main() {
	verifyType()
}
func verifyType() {
	t := T(100)
	fmt.Println(t)
}
```