### PR TITLE
adjust cl and gox error column no entry

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1190,7 +1190,27 @@ type File struct {
 	Code         []byte
 	NoEntrypoint bool // no `main` or `init` func to indicate the module entry point.
 	NoPkgDecl    bool // no `package xxx` declaration
+	NoEntry      *NoEntry
 	FileType     FileType
+}
+
+type NoEntry struct {
+	Entry string
+	Line  int
+	Size  int
+}
+
+func (f *File) AdjustPos(pos token.Position) (token.Position, bool) {
+	var changed bool
+	if f.NoPkgDecl && pos.Line == 1 {
+		pos.Column -= 13 //package main;
+		changed = true
+	}
+	if f.NoEntrypoint && pos.Line == f.NoEntry.Line {
+		pos.Column -= f.NoEntry.Size
+		changed = true
+	}
+	return pos, changed
 }
 
 const (

--- a/ast/filter.go
+++ b/ast/filter.go
@@ -497,6 +497,6 @@ func MergePackageFiles(pkg *Package, mode MergeMode) *File {
 	// TODO(gri) need to compute unresolved identifiers!
 	return &File{
 		doc, pos, NewIdent(pkg.Name), decls, pkg.Scope,
-		imports, nil, comments, nil, false, false, FileTypeGop,
+		imports, nil, comments, nil, false, false, nil, FileTypeGop,
 	}
 }

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -161,6 +161,9 @@ type nodeInterp struct {
 
 func (p *nodeInterp) Position(start token.Pos) token.Position {
 	pos := p.fset.Position(start)
+	if f, ok := p.files[pos.Filename]; ok {
+		pos, _ = f.AdjustPos(pos)
+	}
 	pos.Filename = relFile(p.workingDir, pos.Filename)
 	return pos
 }

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -190,6 +190,9 @@ func (p *nodeInterp) LoadExpr(node ast.Node) (src string, pos token.Position) {
 		log.Println("LoadExpr:", node, pos.Filename, pos.Line, pos.Offset, node.Pos(), node.End(), n)
 	}
 	src = string(f.Code[pos.Offset : pos.Offset+n])
+	if adj, ok := f.AdjustPos(pos); ok {
+		pos.Column = adj.Column
+	}
 	return
 }
 

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -462,8 +462,7 @@ b := []int{2: a}
 }
 
 func TestErrMapLit(t *testing.T) {
-	codeErrorTest(t, // TODO: first column need correct
-		`./bar.gop:2:34: cannot use 1+2 (type untyped int) as type string in map key
+	codeErrorTest(t, `./bar.gop:2:21: cannot use 1+2 (type untyped int) as type string in map key
 ./bar.gop:3:27: cannot use "Go" + "+" (type untyped string) as type int in map value`,
 		`
 a := map[string]int{1+2: 2}

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -159,6 +159,27 @@ func foo(v map[int]bar) {
 `)
 }
 
+func TestErrPosAdjust(t *testing.T) {
+	codeErrorTest(t,
+		"./bar.gop:2:2: undefined: println1", `func main() {
+	println1 "hello"
+}
+`)
+	codeErrorTest(t,
+		"./bar.gop:1:1: undefined: println1", `println1 "hello"`)
+
+	codeErrorTest(t,
+		"./bar.gop:2:2: undefined: println1", `
+	println1 "hello"
+`)
+
+	codeErrorTest(t,
+		"./bar.gop:2:2: undefined: println1", `package main
+	println1 "hello"
+`)
+
+}
+
 func TestErrImport(t *testing.T) {
 	codeErrorTest(t,
 		`./bar.gop:8:2: confliction: NewEncoding declared both in "encoding/base64" and "encoding/base32"`, `


### PR DESCRIPTION
src1
```
println a
```
adjust **gop/cl** pos column 
```
./hello.gop:1:9: undefined: a
```
src2
```
func foo() {}

foo(1)
```
adjust **gox** pos column
```
hello.gop:3:1: too many arguments in call to foo(1)
	have (untyped int)
	want ()
```
