### PR TITLE
cl: support lambda in struct literal 

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2752,6 +2752,23 @@ func main() {
 	})
 }
 `)
+	gopClTest(t, `type Foo struct {
+	Plot func(x float64) (float64, float64)
+}
+foo := &Foo{
+	Plot: x => (x * 2, x * x),
+}`, `package main
+
+type Foo struct {
+	Plot func(x float64) (float64, float64)
+}
+
+func main() {
+	foo := &Foo{Plot: func(x float64) (float64, float64) {
+		return x * 2, x * x
+	}}
+}
+`)
 }
 
 func TestLambdaExpr2(t *testing.T) {
@@ -2796,6 +2813,25 @@ func main() {
 	Do(func() (int, error) {
 		return 100, nil
 	})
+}
+`)
+	gopClTest(t, `type Foo struct {
+	Plot func(x float64) (float64, float64)
+}
+foo := &Foo{
+	Plot: x => {
+		return x * 2, x * x 
+	},
+}`, `package main
+
+type Foo struct {
+	Plot func(x float64) (float64, float64)
+}
+
+func main() {
+	foo := &Foo{Plot: func(x float64) (float64, float64) {
+		return x * 2, x * x
+	}}
 }
 `)
 }

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2769,6 +2769,26 @@ func main() {
 	}}
 }
 `)
+	gopClTest(t, `
+type Fn func(x float64) (float64, float64)
+type Foo struct {
+	Plot Fn
+}
+foo := &Foo{
+	Plot: x => (x * 2, x * x),
+}`, `package main
+
+type Fn func(x float64) (float64, float64)
+type Foo struct {
+	Plot Fn
+}
+
+func main() {
+	foo := &Foo{Plot: func(x float64) (float64, float64) {
+		return x * 2, x * x
+	}}
+}
+`)
 }
 
 func TestLambdaExpr2(t *testing.T) {
@@ -2820,12 +2840,34 @@ func main() {
 }
 foo := &Foo{
 	Plot: x => {
-		return x * 2, x * x 
+		return x * 2, x * x
 	},
 }`, `package main
 
 type Foo struct {
 	Plot func(x float64) (float64, float64)
+}
+
+func main() {
+	foo := &Foo{Plot: func(x float64) (float64, float64) {
+		return x * 2, x * x
+	}}
+}
+`)
+	gopClTest(t, `
+type Fn func(x float64) (float64, float64)
+type Foo struct {
+	Plot Fn
+}
+foo := &Foo{
+	Plot: x => {
+		return x * 2, x * x
+	},
+}`, `package main
+
+type Fn func(x float64) (float64, float64)
+type Foo struct {
+	Plot Fn
 }
 
 func main() {

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -72,6 +72,24 @@ func main() {
 	foo((x, y, z) => {})
 }
 `)
+	codeErrorTest(t, "./bar.gop:6:8: cannot use lambda literal as type int in field value", `
+type Foo struct {
+	Plot int
+}
+foo := &Foo{
+	Plot: x => (x * 2, x * x),
+}
+`)
+	codeErrorTest(t, "./bar.gop:6:8: cannot use lambda literal as type int in field value", `
+type Foo struct {
+	Plot int
+}
+foo := &Foo{
+	Plot: x => {
+		return x * 2, x * x
+	},
+}
+`)
 }
 
 func TestErrErrWrap(t *testing.T) {

--- a/parser/_testdata/lambda4/lambda4.gop
+++ b/parser/_testdata/lambda4/lambda4.gop
@@ -1,0 +1,13 @@
+type Foo struct {
+	Plot func(x float64) (float64, float64)
+}
+
+&Foo{
+	Plot: x => (x * 2, x * x),
+}
+
+&Foo{
+	Plot: x => {
+		return x * 2, x * x
+	},
+}

--- a/parser/_testdata/lambda4/parser.expect
+++ b/parser/_testdata/lambda4/parser.expect
@@ -1,0 +1,132 @@
+package main
+
+file lambda4.gop
+noEntrypoint
+ast.GenDecl:
+  Tok: type
+  Specs:
+    ast.TypeSpec:
+      Name:
+        ast.Ident:
+          Name: Foo
+      Type:
+        ast.StructType:
+          Fields:
+            ast.FieldList:
+              List:
+                ast.Field:
+                  Names:
+                    ast.Ident:
+                      Name: Plot
+                  Type:
+                    ast.FuncType:
+                      Params:
+                        ast.FieldList:
+                          List:
+                            ast.Field:
+                              Names:
+                                ast.Ident:
+                                  Name: x
+                              Type:
+                                ast.Ident:
+                                  Name: float64
+                      Results:
+                        ast.FieldList:
+                          List:
+                            ast.Field:
+                              Type:
+                                ast.Ident:
+                                  Name: float64
+                            ast.Field:
+                              Type:
+                                ast.Ident:
+                                  Name: float64
+ast.FuncDecl:
+  Name:
+    ast.Ident:
+      Name: main
+  Type:
+    ast.FuncType:
+      Params:
+        ast.FieldList:
+  Body:
+    ast.BlockStmt:
+      List:
+        ast.ExprStmt:
+          X:
+            ast.UnaryExpr:
+              Op: &
+              X:
+                ast.CompositeLit:
+                  Type:
+                    ast.Ident:
+                      Name: Foo
+                  Elts:
+                    ast.KeyValueExpr:
+                      Key:
+                        ast.Ident:
+                          Name: Plot
+                      Value:
+                        ast.LambdaExpr:
+                          Lhs:
+                            ast.Ident:
+                              Name: x
+                          Rhs:
+                            ast.BinaryExpr:
+                              X:
+                                ast.Ident:
+                                  Name: x
+                              Op: *
+                              Y:
+                                ast.BasicLit:
+                                  Kind: INT
+                                  Value: 2
+                            ast.BinaryExpr:
+                              X:
+                                ast.Ident:
+                                  Name: x
+                              Op: *
+                              Y:
+                                ast.Ident:
+                                  Name: x
+        ast.ExprStmt:
+          X:
+            ast.UnaryExpr:
+              Op: &
+              X:
+                ast.CompositeLit:
+                  Type:
+                    ast.Ident:
+                      Name: Foo
+                  Elts:
+                    ast.KeyValueExpr:
+                      Key:
+                        ast.Ident:
+                          Name: Plot
+                      Value:
+                        ast.LambdaExpr2:
+                          Lhs:
+                            ast.Ident:
+                              Name: x
+                          Body:
+                            ast.BlockStmt:
+                              List:
+                                ast.ReturnStmt:
+                                  Results:
+                                    ast.BinaryExpr:
+                                      X:
+                                        ast.Ident:
+                                          Name: x
+                                      Op: *
+                                      Y:
+                                        ast.BasicLit:
+                                          Kind: INT
+                                          Value: 2
+                                    ast.BinaryExpr:
+                                      X:
+                                        ast.Ident:
+                                          Name: x
+                                      Op: *
+                                      Y:
+                                        ast.Ident:
+                                          Name: x

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1763,6 +1763,8 @@ func (p *parser) checkExpr(x ast.Expr) ast.Expr {
 	case *ast.BinaryExpr:
 	case *ast.RangeExpr:
 	case *ast.ErrWrapExpr:
+	case *ast.LambdaExpr:
+	case *ast.LambdaExpr2:
 	default:
 		// all other nodes are not proper expressions
 		p.errorExpected(x.Pos(), "expression", 3)


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/933

key:value only
```
type Foo struct {
    Plot func(x float64) (float64, float64)
}

foo := &Foo{
    Plot: x => (x * 2, x * x),
}

bar := &Foo{
    Plot: x => { 
        return x * 2, x * x
    },
}
```
