### PR TITLE
cl: fix lambda for named func call, fix  lambda result untyped check.

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2752,6 +2752,30 @@ func main() {
 	})
 }
 `)
+	gopClTest(t, `
+type Fn func() (int, error)
+func Do(fn Fn) {
+	v, err := fn()
+	println(v, err)
+}
+
+Do => (100, nil)
+`, `package main
+
+import fmt "fmt"
+
+type Fn func() (int, error)
+
+func Do(fn Fn) {
+	v, err := fn()
+	fmt.Println(v, err)
+}
+func main() {
+	Do(func() (int, error) {
+		return 100, nil
+	})
+}
+`)
 }
 
 func TestLambdaExpr2(t *testing.T) {
@@ -2789,6 +2813,32 @@ Do => {
 import fmt "fmt"
 
 func Do(fn func() (int, error)) {
+	v, err := fn()
+	fmt.Println(v, err)
+}
+func main() {
+	Do(func() (int, error) {
+		return 100, nil
+	})
+}
+`)
+	gopClTest(t, `
+type Fn func() (int, error)
+func Do(fn Fn) {
+	v, err := fn()
+	println(v, err)
+}
+
+Do => {
+	return 100, nil
+}
+`, `package main
+
+import fmt "fmt"
+
+type Fn func() (int, error)
+
+func Do(fn Fn) {
 	v, err := fn()
 	fmt.Println(v, err)
 }

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -79,6 +79,12 @@ func foo(int) {
 }
 foo(=> {})
 `)
+	codeErrorTest(t,
+		"./bar.gop:4:5: cannot use lambda literal as type func() in argument to foo", `
+func foo(func()) {
+}
+foo => (100)
+`)
 }
 
 func TestErrErrWrap(t *testing.T) {

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -72,6 +72,13 @@ func main() {
 	foo((x, y, z) => {})
 }
 `)
+
+	codeErrorTest(t,
+		"./bar.gop:4:5: cannot use lambda literal as type int in argument to foo", `
+func foo(int) {
+}
+foo(=> {})
+`)
 }
 
 func TestErrErrWrap(t *testing.T) {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -496,7 +496,8 @@ func compileLambdaExpr(ctx *blockCtx, v *ast.LambdaExpr, fun ast.Expr, sig *type
 	if nout != len(v.Rhs) {
 		pos := ctx.Position(v.Pos())
 		src, _ := ctx.LoadExpr(fun)
-		ctx.handleCodeErrorf(&pos, "cannot use lambda literal as type %v in argument to %v", sig, src)
+		err := newCodeErrorf(&pos, "cannot use lambda literal as type %v in argument to %v", sig, src)
+		panic(err)
 	}
 	results := make([]*types.Var, nout)
 	for i := 0; i < nout; i++ {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -455,7 +455,7 @@ func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, flags int) {
 		case *ast.LambdaExpr2:
 			fn.initWith(fnt, i, len(expr.Lhs))
 			sig := checkLambdaArgumentType(ctx, expr, v.Fun, fn.arg(i, true))
-			compileLambdaExpr2(ctx, expr, sig.Params(), sig.Results())
+			compileLambdaExpr2(ctx, expr, sig)
 		case *ast.CompositeLit:
 			fn.initWith(fnt, i, -1)
 			compileCompositeLit(ctx, expr, fn.arg(i, ellipsis), true)
@@ -510,11 +510,12 @@ func compileLambdaExpr(ctx *blockCtx, v *ast.LambdaExpr, fun ast.Expr, sig *type
 	ctx.cb.Return(nout).End()
 }
 
-func compileLambdaExpr2(ctx *blockCtx, v *ast.LambdaExpr2, in *types.Tuple, out *types.Tuple) {
+func compileLambdaExpr2(ctx *blockCtx, v *ast.LambdaExpr2, sig *types.Signature) {
 	pkg := ctx.pkg
-	params := compileLambdaParams(ctx, v.Pos(), v.Lhs, in)
+	params := compileLambdaParams(ctx, v.Pos(), v.Lhs, sig.Params())
 	cb := ctx.cb
 	comments := cb.Comments()
+	out := sig.Results()
 	nout := out.Len()
 	results := make([]*types.Var, nout)
 	for i := 0; i < nout; i++ {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -418,17 +418,20 @@ func (p *fnType) initWith(fnt types.Type, idx, nin int) {
 	}
 }
 
-func checkTypeSignature(ftyp types.Type) (*types.Signature, bool) {
-	typ := ftyp
+func checkArgumentSignature(ctx *blockCtx, lambda ast.Expr, fun ast.Expr, argTyp types.Type) *types.Signature {
+	typ := argTyp
 retry:
 	switch t := typ.(type) {
 	case *types.Signature:
-		return t, true
+		return t
 	case *types.Named:
 		typ = t.Underlying()
 		goto retry
 	}
-	return nil, false
+	pos := ctx.Position(lambda.Pos())
+	src, _ := ctx.LoadExpr(fun)
+	err := newCodeErrorf(&pos, "cannot use lambda literal as type %v in argument to %v", argTyp, src)
+	panic(err)
 }
 
 func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, flags int) {
@@ -444,24 +447,19 @@ func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, flags int) {
 	fnt := ctx.cb.Get(-1).Type
 	ellipsis := (v.Ellipsis != gotoken.NoPos)
 	for i, arg := range v.Args {
-		if l, ok := arg.(*ast.LambdaExpr); ok {
-			fn.initWith(fnt, i, len(l.Lhs))
-			if sig, ok := checkTypeSignature(fn.arg(i, true)); ok {
-				compileLambdaExpr(ctx, l, sig.Params(), sig.Results())
-				continue
-			}
-		}
-		if l, ok := arg.(*ast.LambdaExpr2); ok {
-			fn.initWith(fnt, i, len(l.Lhs))
-			if sig, ok := checkTypeSignature(fn.arg(i, true)); ok {
-				compileLambdaExpr2(ctx, l, sig.Params(), sig.Results())
-				continue
-			}
-		}
-		if c, ok := arg.(*ast.CompositeLit); ok && c.Type == nil {
+		switch expr := arg.(type) {
+		case *ast.LambdaExpr:
+			fn.initWith(fnt, i, len(expr.Lhs))
+			sig := checkArgumentSignature(ctx, expr, v.Fun, fn.arg(i, true))
+			compileLambdaExpr(ctx, expr, sig.Params(), sig.Results())
+		case *ast.LambdaExpr2:
+			fn.initWith(fnt, i, len(expr.Lhs))
+			sig := checkArgumentSignature(ctx, expr, v.Fun, fn.arg(i, true))
+			compileLambdaExpr2(ctx, expr, sig.Params(), sig.Results())
+		case *ast.CompositeLit:
 			fn.initWith(fnt, i, -1)
-			compileCompositeLit(ctx, c, fn.arg(i, ellipsis), true)
-		} else {
+			compileCompositeLit(ctx, expr, fn.arg(i, ellipsis), true)
+		default:
 			compileExpr(ctx, arg)
 		}
 	}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -418,7 +418,7 @@ func (p *fnType) initWith(fnt types.Type, idx, nin int) {
 	}
 }
 
-func checkArgumentSignature(ctx *blockCtx, lambda ast.Expr, fun ast.Expr, argTyp types.Type) *types.Signature {
+func checkLambdaArgument(ctx *blockCtx, lambda ast.Expr, fun ast.Expr, argTyp types.Type) *types.Signature {
 	typ := argTyp
 retry:
 	switch t := typ.(type) {
@@ -450,11 +450,11 @@ func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, flags int) {
 		switch expr := arg.(type) {
 		case *ast.LambdaExpr:
 			fn.initWith(fnt, i, len(expr.Lhs))
-			sig := checkArgumentSignature(ctx, expr, v.Fun, fn.arg(i, true))
+			sig := checkLambdaArgument(ctx, expr, v.Fun, fn.arg(i, true))
 			compileLambdaExpr(ctx, expr, sig.Params(), sig.Results())
 		case *ast.LambdaExpr2:
 			fn.initWith(fnt, i, len(expr.Lhs))
-			sig := checkArgumentSignature(ctx, expr, v.Fun, fn.arg(i, true))
+			sig := checkLambdaArgument(ctx, expr, v.Fun, fn.arg(i, true))
 			compileLambdaExpr2(ctx, expr, sig.Params(), sig.Results())
 		case *ast.CompositeLit:
 			fn.initWith(fnt, i, -1)

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -418,7 +418,7 @@ func (p *fnType) initWith(fnt types.Type, idx, nin int) {
 	}
 }
 
-func checkLambdaArgument(ctx *blockCtx, lambda ast.Expr, fun ast.Expr, argTyp types.Type) *types.Signature {
+func checkLambdaArgumentType(ctx *blockCtx, lambda ast.Expr, fun ast.Expr, argTyp types.Type) *types.Signature {
 	typ := argTyp
 retry:
 	switch t := typ.(type) {
@@ -450,11 +450,11 @@ func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, flags int) {
 		switch expr := arg.(type) {
 		case *ast.LambdaExpr:
 			fn.initWith(fnt, i, len(expr.Lhs))
-			sig := checkLambdaArgument(ctx, expr, v.Fun, fn.arg(i, true))
+			sig := checkLambdaArgumentType(ctx, expr, v.Fun, fn.arg(i, true))
 			compileLambdaExpr(ctx, expr, sig.Params(), sig.Results())
 		case *ast.LambdaExpr2:
 			fn.initWith(fnt, i, len(expr.Lhs))
-			sig := checkLambdaArgument(ctx, expr, v.Fun, fn.arg(i, true))
+			sig := checkLambdaArgumentType(ctx, expr, v.Fun, fn.arg(i, true))
 			compileLambdaExpr2(ctx, expr, sig.Params(), sig.Results())
 		case *ast.CompositeLit:
 			fn.initWith(fnt, i, -1)


### PR DESCRIPTION
1.  fix lambda for named func call
```
type Fn func() (int, error)
func Do(fn Fn) {
	v, err := fn()
	println(v, err)
}

Do => {
	return 100, nil
}
```
2. fix  lambda result type for untyped
```
- func compileLambdaExpr(ctx *blockCtx, v *ast.LambdaExpr, in *types.Tuple)
+ func compileLambdaExpr(ctx *blockCtx, v *ast.LambdaExpr, in *types.Tuple, out *types.Tuple)
```

3. check lambda and panic
```
func foo(int) {
}
foo(=> {})
```
```
main.gop:3:5: cannot use lambda literal as type int in argument to foo
```