### PR TITLE
add: handle --help, -h and other undefined command line flags

### DIFF
--- a/cmd/gop/main.go
+++ b/cmd/gop/main.go
@@ -56,6 +56,7 @@ func init() {
 }
 
 func main() {
+	flag.Usage = base.Usage
 	flag.Parse()
 	args := flag.Args()
 	if len(args) < 1 {


### PR DESCRIPTION
when user type: `gop -h`, or `gop --help`, now gop will output:

`Usage of gop:`  and nothing else. While `go --help` or `go --not-existed-flag` will output full help usage. 

This PR is just to make gop command more user friendly.