### PR TITLE
Setup CI for windows and mac platforms

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,16 +7,19 @@ on:
     branches: [ main ]
 
 jobs:
-
-  build:
-    runs-on: ubuntu-latest
+  Test:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-latest, macos-11, macos-10.15, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go-version }}
 
     - name: Compile gop and related tools
       run: go run cmd/install.go --build


### PR DESCRIPTION
Setup CI for windows and mac platforms, test with Go 1.16 and 1.17.