### PR TITLE
usage help and error prompt

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&flagBuildOutput, "o", "", "go build output file")
+	flag.StringVar(&flagBuildOutput, "o", "", "gop build output file")
 	Cmd.Run = runCmd
 }
 

--- a/cmd/internal/help/help.go
+++ b/cmd/internal/help/help.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Package help implements the ``go help'' command.
+// Package help implements the ``gop help'' command.
 package help
 
 import (
@@ -27,8 +27,9 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/goplus/gop/cmd/internal/base"
 	"github.com/qiniu/x/log"
+
+	"github.com/goplus/gop/cmd/internal/base"
 )
 
 // Help implements the 'help' command.

--- a/cmd/internal/mod/init.go
+++ b/cmd/internal/mod/init.go
@@ -26,7 +26,7 @@ import (
 )
 
 var cmdInit = &base.Command{
-	UsageLine: "go mod init [module]",
+	UsageLine: "gop mod init [module]",
 	Short:     "initialize new module in current directory",
 }
 

--- a/cmd/internal/modload/modload.go
+++ b/cmd/internal/modload/modload.go
@@ -174,10 +174,10 @@ func findModulePath(dir string) (string, error) {
 	msg := `cannot determine module path for source directory %s (%s)
 
 Example usage:
-	'go mod init example.com/m' to initialize a v0 or v1 module
-	'go mod init example.com/m/v2' to initialize a v2 module
+	'gop mod init example.com/m' to initialize a v0 or v1 module
+	'gop mod init example.com/m/v2' to initialize a v2 module
 
-Run 'go help mod init' for more information.
+Run 'gop help mod init' for more information.
 `
 	return "", fmt.Errorf(msg, dir, reason)
 }

--- a/x/mod/modfile/rule.go
+++ b/x/mod/modfile/rule.go
@@ -395,7 +395,7 @@ func (f *File) add(errs *ErrorList, block *LineBlock, line *Line, verb string, a
 			errorf("gop directive expects exactly one argument")
 			return
 		} else if !GopVersionRE.MatchString(args[0]) {
-			errorf("invalid go version '%s': must match format 1.23", args[0])
+			errorf("invalid gop version '%s': must match format 1.23", args[0])
 			return
 		}
 


### PR DESCRIPTION
modify the 'go' in the usage and error prompts to 'gop'