### PR TITLE
fix the problem that the path to get the class file gop.mod is wrong

### DIFF
--- a/cmd/internal/modload/classfile.go
+++ b/cmd/internal/modload/classfile.go
@@ -58,7 +58,7 @@ func LoadClassFile() {
 		log.Fatalf("gop: can't find classfile path in require statment")
 	}
 
-	gopmod := filepath.Join(dir, "gop.mod")
+	gopmod := filepath.Join(modRoot, dir, "gop.mod")
 	data, err := modfetch.Read(gopmod)
 	if err != nil {
 		log.Fatalf("gop: %v", err)


### PR DESCRIPTION
when the gop operation is inconsistent with the gop.mod directory, the file cannot be obtained by gop.mod