### PR TITLE
docs: update readme for print functions replacement

### DIFF
--- a/x/format/README.md
+++ b/x/format/README.md
@@ -56,11 +56,16 @@ n, err := println("Hello world")
 
 Note:
 
+* Convert `fmt.Errorf => errorf`
+* Convert `fmt.Fprint => fprint`
+* Convert `fmt.Fprintf => fprintf`
+* Convert `fmt.Fprintln => fprintln`
 * Convert `fmt.Print` => `print`
 * Convert `fmt.Printf` => `printf`
 * Convert `fmt.Println` => `println`
-* ...
-
+* Convert `fmt.Sprint => sprint`
+* Convert `fmt.Sprintf => sprintf`
+* Convert `fmt.Sprintln => sprintln`
 
 ### Command style first
 


### PR DESCRIPTION
* Convert `fmt.Errorf => errorf`
* Convert `fmt.Fprint => fprint`
* Convert `fmt.Fprintf => fprintf`
* Convert `fmt.Fprintln => fprintln`
* Convert `fmt.Print` => `print`
* Convert `fmt.Printf` => `printf`
* Convert `fmt.Println` => `println`
* Convert `fmt.Sprint => sprint`
* Convert `fmt.Sprintf => sprintf`
* Convert `fmt.Sprintln => sprintln`