### PR TITLE
supplement readme for io/fs issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 For now, we suggest you install Go+ from source code.
 
+Note: Requires go1.16 or later
+
 ```bash
 git clone https://github.com/goplus/gop.git
 cd gop

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,6 +17,8 @@
 
 当前，我们推荐下载源代码来安装 Go+。
 
+注意：需要 go1.16 或更高版本
+
 ```bash
 git clone https://github.com/goplus/gop.git
 cd gop


### PR DESCRIPTION
Add workarounds to the following issues

`build github.com/goplus/gop/cmd/gop: cannot load io/fs: malformed module path "io/fs": missing dot in first path element`