### PR TITLE
gop run support subpkg

### DIFF
--- a/x/gengo/gengo.go
+++ b/x/gengo/gengo.go
@@ -196,6 +196,10 @@ func (p *Runner) genGoPkgs(conf *Config) {
 		Fset:    conf.Fset,
 	}
 	inModCache := modfetch.InModCachePath(modRoot)
+	if inModCache {
+		os.Chmod(modRoot, 0755)
+		defer os.Chmod(modRoot, 0555)
+	}
 	imp, _, err := packages.NewImporter(impConf, imps...)
 	if err != nil {
 		conf.OnErr("newImporter", err)
@@ -411,7 +415,6 @@ func (p *Runner) genDeps(pkgPath, pkgPathBase string, errs *ErrorList) (pkg *pkg
 	}
 	p.pkgs[pkgPath] = pkg
 	dir := filepath.Join(p.modRoot, pkgPath[len(p.modPath):])
-
 	ci, err := p.mod.ChangeInfo(dir)
 	if err != nil {
 		*errs, pkg.flags = append(*errs, err), pkgFlagIll

--- a/x/gopproj/gopproj.go
+++ b/x/gopproj/gopproj.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/goplus/gop/x/gengo"
 	"github.com/goplus/gop/x/gopprojs"
@@ -99,7 +100,20 @@ func OpenPkgPath(flags int, pkgPath string) (ctx *Context, proj *Project, err er
 	if err != nil {
 		return
 	}
+	pkg, _ := splitVerson(modPath)
+	if strings.HasPrefix(pkg, modVer.Path+"/") {
+		subdir := filepath.Join(dir, pkg[len(modVer.Path)+1:])
+		return OpenDir(flags, subdir)
+	}
 	return OpenDir(flags, dir+leftPart)
+}
+
+func splitVerson(modPath string) (path, version string) {
+	pos := strings.IndexByte(modPath, '@')
+	if pos > 0 {
+		return modPath[:pos], modPath[pos+1:]
+	}
+	return modPath, ""
 }
 
 func splitPkgPath(pkgPath string) (modPath, leftPart string) {

--- a/x/gopproj/projctx.go
+++ b/x/gopproj/projctx.go
@@ -77,6 +77,17 @@ func NewDefault(dir string) *Context {
 	return &Context{modfile: modfile, dir: dir, defctx: true}
 }
 
+func gopGetDefaultPath() (path string) {
+	path = filepath.Join(env.HOME(), ".gop", "get")
+	os.MkdirAll(path, 0755)
+	modfile := filepath.Join(path, "go.mod")
+	err := os.WriteFile(modfile, []byte("module goplus.org/userapp\n\ngo 1.16\n"), 0644)
+	if err != nil {
+		log.Panicln(err)
+	}
+	return
+}
+
 func (p *Context) GoCommand(op string, src *Project) GoCmd {
 	if src.UseDefaultCtx {
 		p = NewDefault(p.dir)

--- a/x/mod/modfetch/fetch.go
+++ b/x/mod/modfetch/fetch.go
@@ -46,7 +46,7 @@ func Get(modPath string, noCache ...bool) (mod module.Version, isClass bool, err
 		}
 	}
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("go", "get", "-x", modPath)
+	cmd := exec.Command("go", "get", "-d", "-x", modPath)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/x/mod/modfetch/fetch.go
+++ b/x/mod/modfetch/fetch.go
@@ -78,11 +78,13 @@ func getResult(data string) (mod module.Version, isClass bool, err error) {
 		}
 		return tryConvGoMod(data[len(downloading):], &data)
 	}
-	// go get: added github.com/xushiwei/foogop v0.1.0
-	const added = "go get: added "
-	if strings.HasPrefix(data, added) {
-		return tryConvGoMod(data[len(added):], &data)
+	// go1.17  go get: added github.com/xushiwei/foogop v0.1.0
+	// go1.18  go: added github.com/xushiwei/foogop v0.1.0
+	const added = ": added "
+	if pos := strings.Index(data, added); pos > 1 {
+		return tryConvGoMod(data[pos+len(added):], &data)
 	}
+	err = fmt.Errorf("unknown go get result: %v", data)
 	return
 }
 

--- a/x/mod/modfetch/fetch.go
+++ b/x/mod/modfetch/fetch.go
@@ -157,6 +157,7 @@ func lookupFromCache(modPath string) (modRoot string, mod module.Version, err er
 	return
 }
 
+// parser from `go get -x pkgpath`
 func parserGetResults(data string) (comment []string, result string) {
 	for _, line := range strings.Split(data, "\n") {
 		if strings.HasPrefix(line, "# get ") {
@@ -172,8 +173,9 @@ func parserGetResults(data string) (comment []string, result string) {
 	return
 }
 
+// found module from go get pkgpath/@v/list comment
+// # get https://goproxy.cn/github.com/goplus/spx/@v/list: 200 OK (0.782s)
 func foundModuleInComment(modPath string, data string) (mod string, ok bool) {
-	// # get https://goproxy.cn/github.com/goplus/spx/@v/list: 200 OK (0.782s)
 	if strings.Contains(data, modPath+"/@v/list") {
 		return modPath, true
 	}
@@ -184,7 +186,8 @@ func foundModuleInComment(modPath string, data string) (mod string, ok bool) {
 	return foundModuleInComment(dir[:len(dir)-1], data)
 }
 
-// github.com/goplus/spx/tutorial/04-Bullet v1.0.0-rc5
+// found pkgpath@ver to modpath@ver
+// github.com/goplus/spx/tutorial/04-Bullet@v1.0.0-rc5 => github.com/goplus/spx@v1.0.0-rc5
 func foundModRoot(modPath string, ver string) (modRoot string, mod string, err error) {
 	modRoot = filepath.Join(GOMODCACHE, modPath+"@"+ver)
 	if fi, e := os.Stat(modRoot); e == nil {
@@ -200,6 +203,7 @@ func foundModRoot(modPath string, ver string) (modRoot string, mod string, err e
 	return foundModRoot(dir[:len(dir)-1], ver)
 }
 
+// found module msg: found, but does not contain package
 func tryFoundModule(modPath string, data string) (mod module.Version, isClass bool, ok bool) {
 	// go get: module github.com/goplus/spx@v1.0.0-rc5 found, but does not contain package github.com/goplus/spx/tutorial/04-Bullet
 	// go get: module github.com/goplus/spx@main found (v1.0.0-rc3.0.20220110030840-d39f5107c481), but does not contain package github.com/goplus/spx/tutorial/00-Hello

--- a/x/mod/modfetch/fetch.go
+++ b/x/mod/modfetch/fetch.go
@@ -163,11 +163,9 @@ func parserGetResults(data string) (comment []string, result string) {
 			if strings.Contains(line, "@v/list: 200 OK") {
 				comment = append(comment, line)
 			}
-		} else if strings.HasPrefix(line, "go: downloading ") {
+		} else if strings.HasPrefix(line, "go: ") {
 			result = line + "\n"
-		} else if strings.HasPrefix(line, "go: module ") {
-			result = line + "\n"
-		} else if strings.HasPrefix(line, "go get: module ") {
+		} else if strings.HasPrefix(line, "go get: ") {
 			result = line + "\n"
 		}
 	}


### PR DESCRIPTION
support gop run subpkg

generate go get work mod $HOME/.gop/get/go.mod

```
gop run github.com/goplus/spx/tutorial/04-Bullet@v1.0.0-rc5
```
parse modpath `GOMODCACHE/github.com/goplus/spx@v1.0.0-rc5`

go get command
```
$ go get -d -x github.com/goplus/spx/tutorial/04-Bullet@v1.0.0-rc5
```

1. go get error message
```
// go get -x github.com/goplus/spx/tutorial/04-Bullet@v1.0.0-rc5
go get: module github.com/goplus/spx@v1.0.0-rc5 found, but does not contain package github.com/goplus/spx/tutorial/04-Bullet

// go get -x github.com/goplus/spx/tutorial/00-Hello
go get: module github.com/goplus/spx@main found (v1.0.0-rc3.0.20220110030840-d39f5107c481), but does not contain package github.com/goplus/spx/tutorial/00-Hello
```
2. go get success message
```
# get https://goproxy.cn/github.com/goplus/spx/@v/list: 200 OK (0.782s)
```

