### PR TITLE
x/gopproj: fix gop run workdir

### DIFF
--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -91,6 +91,11 @@ func gopRun(args []string) {
 	if *flagGop {
 		flags = gopproj.FlagGoAsGoPlus
 	}
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Get current directory failed:", err)
+		os.Exit(1)
+	}
 	ctx, goProj, err := gopproj.OpenProject(flags, proj)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "OpenProject failed:", err)
@@ -107,6 +112,7 @@ func gopRun(args []string) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
+	cmd.Dir = wd
 	err = cmd.Run()
 	if err != nil {
 		switch e := err.(type) {

--- a/x/gopproj/gopproj.go
+++ b/x/gopproj/gopproj.go
@@ -72,8 +72,10 @@ func OpenProject(flags int, src gopprojs.Proj) (ctx *Context, proj *Project, err
 		proj, err = ctx.OpenFiles(flags, v.Files...)
 		return
 	case *gopprojs.DirProj:
+		os.Chdir(v.Dir)
 		return OpenDir(flags, v.Dir)
 	case *gopprojs.PkgPathProj:
+		os.Chdir(modfetch.GOMODCACHE)
 		return OpenPkgPath(flags, v.Path)
 	}
 	panic("OpenProject: unexpected source")


### PR DESCRIPTION
1. gop run localdir

- store current dir to _wd_
- change current  dir to localdir for go.mod
- gen go code
- reset  go run dir to _wd_

2. gop run pkg
- store current dir to _wd_
- change current to `GOMODCACHE` for go.mod
- gen go code
- reset  go run dir to _wd_






