### PR TITLE
x/gopproj: go run support go project only

### DIFF
--- a/x/gopproj/gopproj.go
+++ b/x/gopproj/gopproj.go
@@ -86,8 +86,12 @@ func OpenDir(flags int, dir string) (ctx *Context, proj *Project, err error) {
 	if !gengo.GenGo(gengo.Config{Event: ev}, false, dir, dir) {
 		return nil, nil, ev.lastErr
 	}
+	gofile := filepath.Join(dir, "gop_autogen.go")
+	if _, err = os.Stat(gofile); err != nil {
+		return nil, nil, fmt.Errorf("no Gop files in %v", dir)
+	}
 	ctx = New(dir)
-	proj, err = ctx.OpenFiles(0, filepath.Join(dir, "gop_autogen.go"))
+	proj, err = ctx.OpenFiles(0, gofile)
 	return
 }
 

--- a/x/gopproj/projctx.go
+++ b/x/gopproj/projctx.go
@@ -53,6 +53,7 @@ type Project struct {
 	ForceToGen    bool
 	FlagNRINC     bool // do not run if not changed
 	FlagRTOE      bool // remove tempfile on error
+	GoProjectOnly bool
 }
 
 type Context struct {
@@ -78,6 +79,12 @@ func NewDefault(dir string) *Context {
 }
 
 func (p *Context) GoCommand(op string, src *Project) GoCmd {
+	if src.GoProjectOnly {
+		args := []string{op, p.dir}
+		args = append(args, src.ExecArgs...)
+		cmd := exec.Command("go", args...)
+		return GoCmd{Cmd: cmd}
+	}
 	if src.UseDefaultCtx {
 		p = NewDefault(p.dir)
 	}


### PR DESCRIPTION
`go run demo args`

1. go files only : exec by `go run demo args`
2. no go or gop file:  dump `no Gop files in demo`
