### PR TITLE
cl: check struct type fields name redeclared

### DIFF
--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -810,13 +810,16 @@ n, err := fmt.println
 func TestFiledsNameRedecl(t *testing.T) {
 	codeErrorTest(t, `./bar.gop:6:2: Id redeclared
 	./bar.gop:5:2 other declaration of Id
-./bar.gop:8:2: name redeclared
-	./bar.gop:7:2 other declaration of name`, `
+./bar.gop:7:2: Id redeclared
+	./bar.gop:5:2 other declaration of Id
+./bar.gop:9:2: name redeclared
+	./bar.gop:8:2 other declaration of name`, `
 type Id struct {
 }
 type A struct {
 	Id
 	Id   int
+	Id   string
 	name string
 	name string
 }

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -806,3 +806,19 @@ import "fmt"
 n, err := fmt.println
 `)
 }
+
+func TestFiledsNameRedecl(t *testing.T) {
+	codeErrorTest(t, `./bar.gop:6:2: Id redeclared
+	./bar.gop:5:2 other declaration of Id
+./bar.gop:8:2: name redeclared
+	./bar.gop:7:2 other declaration of name`, `
+type Id struct {
+}
+type A struct {
+	Id
+	Id   int
+	name string
+	name string
+}
+`)
+}

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -817,9 +817,9 @@ func TestFiledsNameRedecl(t *testing.T) {
 type Id struct {
 }
 type A struct {
-	Id
 	Id   int
 	Id   string
+	Id
 	name string
 	name string
 }

--- a/cl/func_type_and_var.go
+++ b/cl/func_type_and_var.go
@@ -209,15 +209,33 @@ func toStructType(ctx *blockCtx, v *ast.StructType) *types.Struct {
 	fieldList := v.Fields.List
 	fields := make([]*types.Var, 0, len(fieldList))
 	tags := make([]string, 0, len(fieldList))
+	names := make(map[string]token.Pos)
+	chkRedecl := func(name string, pos token.Pos) bool {
+		if opos, ok := names[name]; ok {
+			npos := ctx.Position(pos)
+			ctx.handleCodeErrorf(&npos, "%v redeclared\n\t%v other declaration of %v",
+				name, ctx.Position(opos), name)
+			return true
+		}
+		names[name] = pos
+		return false
+	}
 	for _, field := range fieldList {
 		typ := toType(ctx, field.Type)
 		if field.Names == nil { // embedded
-			fld := types.NewField(token.NoPos, pkg, getTypeName(typ), typ, true)
+			name := getTypeName(typ)
+			if chkRedecl(name, field.Type.Pos()) {
+				continue
+			}
+			fld := types.NewField(token.NoPos, pkg, name, typ, true)
 			fields = append(fields, fld)
 			tags = append(tags, toFieldTag(field.Tag))
 			continue
 		}
 		for _, name := range field.Names {
+			if chkRedecl(name.Name, name.NamePos) {
+				continue
+			}
 			fld := types.NewField(token.NoPos, pkg, name.Name, typ, false)
 			fields = append(fields, fld)
 			tags = append(tags, toFieldTag(field.Tag))

--- a/cl/func_type_and_var.go
+++ b/cl/func_type_and_var.go
@@ -211,6 +211,9 @@ func toStructType(ctx *blockCtx, v *ast.StructType) *types.Struct {
 	tags := make([]string, 0, len(fieldList))
 	names := make(map[string]token.Pos)
 	chkRedecl := func(name string, pos token.Pos) bool {
+		if name == "_" {
+			return false
+		}
 		if opos, ok := names[name]; ok {
 			npos := ctx.Position(pos)
 			ctx.handleCodeErrorf(&npos, "%v redeclared\n\t%v other declaration of %v",


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/1060

```
type Id struct {
}
type A struct {
	Id
	Id   int
	Id   string
	name string
	name string
}
```
error message compatible for **Go1.18** compile error message.
```
./bar.gop:6:2: Id redeclared
	./bar.gop:5:2 other declaration of Id
./bar.gop:7:2: Id redeclared
	./bar.gop:5:2 other declaration of Id
./bar.gop:9:2: name redeclared
	./bar.gop:8:2 other declaration of name
```

not used **Go1.16** compile error message.
```
./bar.go:13:2: duplicate field Id
./bar.go:14:2: duplicate field Id
./bar.go:16:2: duplicate field name
```
