### PR TITLE
cl: check main package no entry and added empty

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -96,6 +96,9 @@ type Config struct {
 
 	// RelativePath = true means to generate file line comments with relative file path.
 	RelativePath bool
+
+	// NoAutoGenMain = true means not to auto generate main func is no entry.
+	NoAutoGenMain bool
 }
 
 type nodeInterp struct {
@@ -543,7 +546,7 @@ func preloadFile(p *gox.Package, parent *pkgCtx, file string, f *ast.File, targe
 		}}}
 	}
 	// check main package no entry and added emtpy
-	if f.Name.Name == "main" && !f.NoEntrypoint {
+	if !conf.NoAutoGenMain && f.Name.Name == "main" && !f.NoEntrypoint {
 		entry := getEntrypoint(f, false)
 		var hasEntry bool
 		for _, decl := range f.Decls {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -542,6 +542,26 @@ func preloadFile(p *gox.Package, parent *pkgCtx, file string, f *ast.File, targe
 			},
 		}}}
 	}
+	// check main package no entry and added emtpy
+	if f.Name.Name == "main" && !f.NoEntrypoint {
+		entry := getEntrypoint(f, false)
+		var hasEntry bool
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Name.Name == entry {
+					hasEntry = true
+				}
+			}
+		}
+		if !hasEntry {
+			f.Decls = append(f.Decls, &ast.FuncDecl{
+				Name: ast.NewIdent(entry),
+				Type: &ast.FuncType{Params: &ast.FieldList{}},
+				Body: &ast.BlockStmt{},
+			})
+		}
+	}
 	for _, decl := range f.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -399,6 +399,15 @@ func NewPackage(pkgPath string, pkg *ast.Package, conf *Config) (p *gox.Package,
 		load()
 	}
 	err = ctx.complete()
+
+	if !conf.NoAutoGenMain && pkg.Name == "main" {
+		if obj := p.Types.Scope().Lookup("main"); obj == nil {
+			old := p.SetInTestingFile(false)
+			p.NewFunc(nil, "main", nil, nil, false).BodyStart(p).End()
+			p.SetInTestingFile(old)
+		}
+	}
+
 	return
 }
 
@@ -546,7 +555,7 @@ func preloadFile(p *gox.Package, parent *pkgCtx, file string, f *ast.File, targe
 		}}}
 	}
 	// check main package no entry and added emtpy
-	if !conf.NoAutoGenMain && f.Name.Name == "main" && !f.NoEntrypoint {
+	if !conf.NoAutoGenMain && f.IsClass && !f.NoEntrypoint && f.Name.Name == "main" {
 		entry := getEntrypoint(f, false)
 		var hasEntry bool
 		for _, decl := range f.Decls {

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -3624,6 +3624,7 @@ func main() {
 func TestMainEntry(t *testing.T) {
 	conf := *gblConf
 	conf.NoAutoGenMain = false
+
 	gopClTestEx(t, &conf, "main", `
 `, `package main
 

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -3621,7 +3621,7 @@ func main() {
 `)
 }
 
-func TestMainNoEntry(t *testing.T) {
+func TestMainEntry(t *testing.T) {
 	conf := *gblConf
 	conf.NoAutoGenMain = false
 	gopClTestEx(t, &conf, "main", `
@@ -3642,6 +3642,19 @@ func test() {
 	fmt.Println("hello")
 }
 func main() {
+}
+`)
+
+	gopClTestEx(t, &conf, "main", `
+func main() {
+	println "hello"
+}
+`, `package main
+
+import fmt "fmt"
+
+func main() {
+	fmt.Println("hello")
 }
 `)
 }

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -3619,3 +3619,26 @@ func main() {
 }
 `)
 }
+
+func TestMainNoEntry(t *testing.T) {
+	gopClTest(t, `
+`, `package main
+
+func main() {
+}
+`)
+	gopClTest(t, `
+func test() {
+	println "hello"
+}
+`, `package main
+
+import fmt "fmt"
+
+func test() {
+	fmt.Println("hello")
+}
+func main() {
+}
+`)
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -60,18 +60,19 @@ func init() {
 		panic(err)
 	}
 	gblConf = &cl.Config{
-		Fset:        gblFset,
-		Importer:    imp,
-		LookupClass: lookupClass,
-		NoFileLine:  true,
+		Fset:          gblFset,
+		Importer:      imp,
+		LookupClass:   lookupClass,
+		NoFileLine:    true,
+		NoAutoGenMain: true,
 	}
 }
 
 func gopClTest(t *testing.T, gopcode, expected string) {
-	gopClTestEx(t, "main", gopcode, expected)
+	gopClTestEx(t, gblConf, "main", gopcode, expected)
 }
 
-func gopClTestEx(t *testing.T, pkgname, gopcode, expected string) {
+func gopClTestEx(t *testing.T, conf *cl.Config, pkgname, gopcode, expected string) {
 	cl.SetDisableRecover(true)
 	defer cl.SetDisableRecover(false)
 
@@ -82,7 +83,7 @@ func gopClTestEx(t *testing.T, pkgname, gopcode, expected string) {
 		t.Fatal("ParseFSDir:", err)
 	}
 	bar := pkgs[pkgname]
-	pkg, err := cl.NewPackage("github.com/goplus/gop/cl", bar, gblConf)
+	pkg, err := cl.NewPackage("github.com/goplus/gop/cl", bar, conf)
 	if err != nil {
 		t.Fatal("NewPackage:", err)
 	}
@@ -3515,7 +3516,7 @@ func main() {
 	fmt.Println("init")
 }
 `)
-	gopClTestEx(t, "bar", `package bar
+	gopClTestEx(t, gblConf, "bar", `package bar
 println("init")
 `, `package bar
 
@@ -3621,13 +3622,15 @@ func main() {
 }
 
 func TestMainNoEntry(t *testing.T) {
-	gopClTest(t, `
+	conf := *gblConf
+	conf.NoAutoGenMain = false
+	gopClTestEx(t, &conf, "main", `
 `, `package main
 
 func main() {
 }
 `)
-	gopClTest(t, `
+	gopClTestEx(t, &conf, "main", `
 func test() {
 	println "hello"
 }


### PR DESCRIPTION
`cl.Config add NoAutoGenMain bool`
fix https://github.com/goplus/gop/issues/1017

**empty .gop**
```
//blink
```
generate to
```
package main

func main() {
}
```

**no entry .gop**
```
func test() {
	println "hello"
}
```

generate
```
package main

import fmt "fmt"

func test() {
	fmt.Println("hello")
}
func main() {
}
```

**no entry index.gmx**
```
func (this *Game) MainEntry() {
}
```
**no entry Kai.spx**
```
func (this *Kai) Main() {
}
```
