### PR TITLE
cl: fix #1243 for rangeExpr if pos

### DIFF
--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -393,6 +393,7 @@ func toForStmt(forPos token.Pos, value ast.Expr, body *ast.BlockStmt, re *ast.Ra
 	}
 	if fp != nil && fp.Cond != nil {
 		condStmt := &ast.IfStmt{
+			If:   fp.Cond.Pos(),
 			Init: fp.Init,
 			Cond: fp.Cond,
 			Body: body,


### PR DESCRIPTION
// main.gop
```
for i <- :10, i%3 == 0 {
	println i
}
```
// go run main.gop bug
```
main.gop:2: invalid line number: 0
```

this PR fixed but gop fmt this file to
```
for i <- :10 if i%3 == 0 {
	println i
}
```
