### PR TITLE
cl: preloadFile restore cur file

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -619,7 +619,8 @@ func preloadFile(p *gox.Package, ctx *blockCtx, file string, f *ast.File, genCod
 	parent := ctx.pkgCtx
 	syms := parent.syms
 	goFile := getGoFile(file, genCode)
-	p.SetCurFile(goFile, true)
+	old, _ := p.SetCurFile(goFile, true)
+	defer p.RestoreCurFile(old)
 	for _, decl := range f.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -147,6 +147,25 @@ var d int = c.v
 var e = foo3{}
 var x string = c.Str()
 `)
+	gopMixedClTest(t, "main", `package main
+type Point struct {
+	X int
+	Y int
+}
+`, `
+type T struct{}
+println(&T{},&Point{10,20})
+`, `package main
+
+import fmt "fmt"
+
+type T struct {
+}
+
+func main() {
+	fmt.Println(&T{}, &Point{10, 20})
+}
+`)
 }
 
 func Test_RangeExpressionIf_Issue1243(t *testing.T) {


### PR DESCRIPTION
fix mixed .go and .gop
cl preloadFile restore current file.