### PR TITLE
Avoiding environment variable exceptions

### DIFF
--- a/all.bash
+++ b/all.bash
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+source /etc/profile
 set -ex
 
 go run cmd/make.go --install --autoproxy


### PR DESCRIPTION
I'm not sure if everyone needs to refresh their environment variables

But it does solve a problem I've been having lately

Before adding：
![image](https://user-images.githubusercontent.com/73827386/173364053-cde9526c-2651-4def-99c3-1af92ebffb93.png)

After adding：
![image](https://user-images.githubusercontent.com/73827386/173364492-f45ddd0e-ea88-4c80-9d3c-1fb54710ac97.png)
