### PR TITLE
parser: parseBinaryExpr check tuple

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1733,7 +1733,7 @@ func (p *parser) parseLiteralValue(typ ast.Expr) ast.Expr {
 
 // checkExpr checks that x is an expression (and not a type).
 func (p *parser) checkExpr(x ast.Expr) ast.Expr {
-	switch unparen(x).(type) {
+	switch v := unparen(x).(type) {
 	case *ast.BadExpr:
 	case *ast.Ident:
 	case *ast.BasicLit:
@@ -1758,6 +1758,8 @@ func (p *parser) checkExpr(x ast.Expr) ast.Expr {
 	case *ast.ErrWrapExpr:
 	case *ast.LambdaExpr:
 	case *ast.LambdaExpr2:
+	case *tupleExpr:
+		p.error(v.opening, "tuple is not supported")
 	default:
 		// all other nodes are not proper expressions
 		p.errorExpected(x.Pos(), "expression", 3)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -372,6 +372,7 @@ ast.FuncDecl:
 func TestErrTuple(t *testing.T) {
 	testErrCode(t, `println (1,2)*2`, `/foo/bar.gop:1:9: tuple is not supported`, ``)
 	testErrCode(t, `println 2*(1,2)`, `/foo/bar.gop:1:11: tuple is not supported`, ``)
+	testErrCode(t, `func test() (int,int) { return (100,100)`, `/foo/bar.gop:1:32: tuple is not supported`, ``)
 }
 
 // -----------------------------------------------------------------------------

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -369,4 +369,9 @@ ast.FuncDecl:
 `)
 }
 
+func TestErrTuple(t *testing.T) {
+	testErrCode(t, `println (1,2)*2`, `/foo/bar.gop:1:9: tuple is not supported`, ``)
+	testErrCode(t, `println 2*(1,2)`, `/foo/bar.gop:1:11: tuple is not supported`, ``)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
```
println (1,2)*2
```
`main.gop:1:9: tuple is not supported`