### PR TITLE
docs:  update homebrew install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ cd gop
 all.bat
 ```
 
-### on macOS
+### on macOS/Linux
 
+Install via [brew](https://brew.sh/)
 ```sh
-brew install goplus
+$ brew install goplus
 ```
 
 


### PR DESCRIPTION
goplus can be installed for both macOS and Linux, https://formulae.brew.sh/formula/goplus

fixes #1349 