### PR TITLE
cl: classfile WorkExt support multiple ext

### DIFF
--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -148,9 +148,9 @@ func TestSpxLookup(t *testing.T) {
 
 func lookupClass(ext string) (c *gopmod.Class, ok bool) {
 	switch ext {
-	case ".t2gmx", ".t2spx":
+	case ".t2gmx", ".t2spx", ".t2spx2":
 		return &gopmod.Class{
-			ProjExt: ".t2gmx", WorkExt: ".t2spx",
+			ProjExt: ".t2gmx", WorkExt: ".t2spx;.t2spx2",
 			PkgPaths: []string{"github.com/goplus/gop/cl/internal/spx2"}}, true
 	}
 	return
@@ -158,9 +158,9 @@ func lookupClass(ext string) (c *gopmod.Class, ok bool) {
 
 func lookupClassErr(ext string) (c *gopmod.Class, ok bool) {
 	switch ext {
-	case ".t2gmx", ".t2spx":
+	case ".t2gmx", ".t2spx", ".t2spx2":
 		return &gopmod.Class{
-			ProjExt: ".t2gmx", WorkExt: ".t2spx",
+			ProjExt: ".t2gmx", WorkExt: ".t2spx;.t2spx2",
 			PkgPaths: []string{"github.com/goplus/gop/cl/internal/libc"}}, true
 	}
 	return

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -535,7 +535,18 @@ func preloadGopFile(p *gox.Package, ctx *blockCtx, file string, f *ast.File, con
 		if parent.gmxSettings != nil {
 			classType = getDefaultClass(file)
 			o := parent.sprite
-			baseTypeName, baseType, spxClass = o.Name(), o.Type(), true
+			spxClass = true
+			var index = 0
+			if len(o) == len(parent.extSpx) {
+				for i, v := range parent.extSpx {
+					if strings.HasSuffix(file, v) {
+						index = i
+						break
+					}
+				}
+			}
+			baseTypeName = o[index].Name()
+			baseType = o[index].Type()
 		}
 		// TODO: panic
 	}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -534,10 +534,10 @@ func preloadGopFile(p *gox.Package, ctx *blockCtx, file string, f *ast.File, con
 	case f.IsClass:
 		if parent.gmxSettings != nil {
 			classType = getDefaultClass(file)
-			o := parent.sprite
 			spxClass = true
+			o := parent.sprite
 			var index = 0
-			if len(o) == len(parent.extSpx) {
+			if n := len(o); n > 1 && n == len(parent.extSpx) {
 				for i, v := range parent.extSpx {
 					if strings.HasSuffix(file, v) {
 						index = i

--- a/cl/compile_spx_test.go
+++ b/cl/compile_spx_test.go
@@ -34,9 +34,9 @@ func lookupClass(ext string) (c *gopmod.Class, ok bool) {
 		return &gopmod.Class{
 			ProjExt: ".tgmx", WorkExt: ".tspx",
 			PkgPaths: []string{"github.com/goplus/gop/cl/internal/spx", "math"}}, true
-	case ".t2gmx", ".t2spx":
+	case ".t2gmx", ".t2spx", ".t2spx2":
 		return &gopmod.Class{
-			ProjExt: ".t2gmx", WorkExt: ".t2spx",
+			ProjExt: ".t2gmx", WorkExt: ".t2spx;.t2spx2",
 			PkgPaths: []string{"github.com/goplus/gop/cl/internal/spx2"}}, true
 	}
 	return
@@ -389,6 +389,40 @@ type Kai struct {
 func (this *Kai) onMsg(msg string) {
 }
 `, "Game.t2gmx", "Kai.t2spx")
+}
+
+func TestSpx2_2(t *testing.T) {
+	gopSpxTestEx(t, `
+println("Hi")
+`, `
+func onMsg(msg string) {
+}
+`, `package main
+
+import (
+	fmt "fmt"
+	spx2 "github.com/goplus/gop/cl/internal/spx2"
+)
+
+type Game struct {
+	spx2.Game
+}
+
+func (this *Game) MainEntry() {
+	fmt.Println("Hi")
+}
+func main() {
+	new(Game).Main()
+}
+
+type Kai struct {
+	spx2.Sprite2
+	*Game
+}
+
+func (this *Kai) onMsg(msg string) {
+}
+`, "Game.t2gmx", "Kai.t2spx2")
 }
 
 func TestSpxMainEntry(t *testing.T) {

--- a/cl/internal/spx2/spx2.go
+++ b/cl/internal/spx2/spx2.go
@@ -18,7 +18,7 @@ package spx2
 
 const (
 	Gop_sched = "Sched"
-	Gop_work  = "Sprite"
+	Gop_work  = "Sprite;Sprite2"
 )
 
 type Game struct {
@@ -28,6 +28,9 @@ func (p *Game) Main() {
 }
 
 type Sprite struct {
+}
+
+type Sprite2 struct {
 }
 
 func Sched() {


### PR DESCRIPTION
support  register multiple ext work files split by ; list
`classfile .gmx .spx;.spy github.com/goplus/spx`
`Gop_sprite = "Sprite;Sprite2"`

**TODO** https://github.com/goplus/mod/pull/8 for cmd/gop support multiple ext