### PR TITLE
fix empty struct argument call for gop style

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2011,6 +2011,8 @@ func bar(conf ...Config) {
 
 foo({A: 1})
 bar({A: 2})
+foo({})
+bar({})
 `, `package main
 
 type Config struct {
@@ -2024,6 +2026,8 @@ func bar(conf ...Config) {
 func main() {
 	foo(&Config{A: 1})
 	bar(Config{A: 2})
+	foo(&Config{})
+	bar(Config{})
 }
 `)
 }

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -683,11 +683,14 @@ const (
 	compositeLitKeyVal = 1
 )
 
-func checkCompositeLitElts(ctx *blockCtx, elts []ast.Expr) (kind int) {
+func checkCompositeLitElts(ctx *blockCtx, elts []ast.Expr, onlyStruct bool) (kind int) {
 	for _, elt := range elts {
 		if _, ok := elt.(*ast.KeyValueExpr); ok {
 			return compositeLitKeyVal
 		}
+	}
+	if len(elts) == 0 && onlyStruct {
+		return compositeLitKeyVal
 	}
 	return compositeLitVal
 }
@@ -793,7 +796,7 @@ func getUnderlying(ctx *blockCtx, typ types.Type) types.Type {
 func compileCompositeLit(ctx *blockCtx, v *ast.CompositeLit, expected types.Type, onlyStruct bool) {
 	var hasPtr bool
 	var typ, underlying types.Type
-	var kind = checkCompositeLitElts(ctx, v.Elts)
+	var kind = checkCompositeLitElts(ctx, v.Elts, onlyStruct)
 	if v.Type != nil {
 		typ = toType(ctx, v.Type)
 		underlying = getUnderlying(ctx, typ)


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/1367

```
func CreateBox(name string, opt Option) {
	println(name,opt)
}

CreateBox("box",{Size:1}) // ok
CreateBox("box",{}) // fixed build pass
```