### PR TITLE
cl: loadVars check recover

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1042,6 +1042,14 @@ func loadVars(ctx *blockCtx, v *ast.ValueSpec, global bool) {
 	varDecl := ctx.pkg.NewVarEx(scope, v.Names[0].Pos(), typ, names...)
 	if nv := len(v.Values); nv > 0 {
 		cb := varDecl.InitStart(ctx.pkg)
+		if enableRecover {
+			defer func() {
+				if e := recover(); e != nil {
+					cb.ResetInit()
+					panic(e)
+				}
+			}()
+		}
 		if nv == 1 && len(names) == 2 {
 			compileExpr(ctx, v.Values[0], clCallWithTwoValue)
 		} else {

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -876,7 +876,7 @@ func set(name string, v int) string {
 	return name
 }
 func test() {
-	var a = set("box") 
+	var a = set("box")
 	println(a)
 }
 `)

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -866,3 +866,18 @@ import (
 )
 `)
 }
+
+func TestErrVarInFunc(t *testing.T) {
+	codeErrorTest(t, `./bar.gop:6:10: too few arguments in call to set("box")
+	have (untyped string)
+	want (name string, v int)
+./bar.gop:7:10: undefined: a`, `
+func set(name string, v int) string {
+	return name
+}
+func test() {
+	var a = set("box") 
+	println(a)
+}
+`)
+}


### PR DESCRIPTION
fix #1369 , loadVars check recover and resetInit
```
func set(name string, v int) string {
	return name
}

func test() {
	var a = set("box")  // dump error
	println(a)
}
```
`gop run` can dump error info
```
./main.gop:6:10: too few arguments in call to set("box")
	have (untyped string)
	want (name string, v int)
./main.gop:7:10: undefined: a
```