### PR TITLE
builtin: compiler check untyped overflows for int128/uint128

### DIFF
--- a/builtin/ng/int128.go
+++ b/builtin/ng/int128.go
@@ -8,6 +8,12 @@ import (
 )
 
 const (
+	Int128_Max       = 1<<127 - 1
+	Int128_Min       = -1 << 127
+	Int128_IsUntyped = true
+)
+
+const (
 	signBit  = 0x8000000000000000
 	maxInt64 = 1<<63 - 1
 )
@@ -634,7 +640,6 @@ func (i Int128) Gop_Rsh(n Gop_ninteger) Int128 {
 // Mul returns the product of two I128s.
 //
 // Overflow should wrap around, as per the Go spec.
-//
 func (i Int128) Gop_Mul__1(n Int128) (dest Int128) {
 	hi, lo := bits.Mul64(i.lo, n.lo)
 	hi += i.hi*n.lo + i.lo*n.hi

--- a/builtin/ng/uint128.go
+++ b/builtin/ng/uint128.go
@@ -13,6 +13,12 @@ const (
 )
 
 const (
+	Uint128_Max       = 1<<128 - 1
+	Uint128_Min       = 0
+	Uint128_IsUntyped = true
+)
+
+const (
 	maxUint64 = (1 << 64) - 1
 	intSize   = 32 << (^uint(0) >> 63)
 )
@@ -349,7 +355,6 @@ func (u Uint128) ReverseBytes() Uint128 {
 //
 // The specific value returned by Cmp is undefined, but it is guaranteed to
 // satisfy the above constraints.
-//
 func (u Uint128) Cmp__1(n Uint128) int {
 	if u.hi == n.hi {
 		if u.lo > n.lo {

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -902,3 +902,38 @@ func test() {
 }
 `)
 }
+
+func TestErrInt128(t *testing.T) {
+	codeErrorTest(t, `./bar.gop:2:16: cannot use 1<<127 (type untyped int) as type github.com/goplus/gop/builtin/ng.Int128 in assignment`, `
+var a int128 = 1<<127
+`)
+	codeErrorTest(t, `./bar.gop:2:13: cannot convert 1<<127 (untyped int constant 170141183460469231731687303715884105728) to type Int128`, `
+a := int128(1<<127)
+`)
+	codeErrorTest(t, `./bar.gop:2:13: cannot convert -1<<127-1 (untyped int constant -170141183460469231731687303715884105729) to type Int128`, `
+a := int128(-1<<127-1)
+`)
+	codeErrorTest(t, `./bar.gop:3:13: cannot convert b (untyped int constant -170141183460469231731687303715884105729) to type Int128`, `
+const b = -1<<127-1
+a := int128(b)
+`)
+}
+
+func TestErrUint128(t *testing.T) {
+	codeErrorTest(t, `./bar.gop:2:17: cannot use 1<<128 (type untyped int) as type github.com/goplus/gop/builtin/ng.Uint128 in assignment`, `
+var a uint128 = 1<<128
+`)
+	codeErrorTest(t, `./bar.gop:2:14: cannot convert 1<<128 (untyped int constant 340282366920938463463374607431768211456) to type Uint128`, `
+a := uint128(1<<128)
+`)
+	codeErrorTest(t, `./bar.gop:2:17: cannot use -1 (type untyped int) as type github.com/goplus/gop/builtin/ng.Uint128 in assignment`, `
+var a uint128 = -1
+`)
+	codeErrorTest(t, `./bar.gop:2:14: cannot convert -1 (untyped int constant -1) to type Uint128`, `
+a := uint128(-1)
+`)
+	codeErrorTest(t, `./bar.gop:3:14: cannot convert b (untyped int constant -1) to type Uint128`, `
+const b = -1
+a := uint128(b)
+`)
+}


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/1323