### PR TITLE
fix: hong kong locale does not always mean china

### DIFF
--- a/cmd/make.go
+++ b/cmd/make.go
@@ -452,7 +452,7 @@ func isInChinaWindows() bool {
 		return false
 	}
 	// Check if output contains `zh-cn;`
-	return strings.Contains(out, "zh-cn;") || strings.Contains(out, "zh-hk;")
+	return strings.Contains(out, "zh-cn;")
 }
 
 func isInChina() bool {
@@ -466,7 +466,7 @@ func isInChina() bool {
 	}
 	if strings.HasPrefix(out, prefix) {
 		out = out[len(prefix):]
-		return strings.HasPrefix(out, "zh_CN") || strings.HasPrefix(out, "zh_HK")
+		return strings.HasPrefix(out, "zh_CN")
 	}
 	return false
 }


### PR DESCRIPTION
hello, thank you so much for this project 👍🏻

a [previous commit](https://github.com/goplus/gop/pull/1387/commits/c45906e8fbd1f5611a1222204724822260037182) by @92hackers set this conditional to return as `true` when the observed windows locale contains `zh-hk`, and then applies `GOPROXY` setting based on such detection.

the flag is supposed to _Set GOPROXY for people in China_ ([source code](https://github.com/goplus/gop/blob/main/cmd/make.go#L550)). if this flag is truthy, the proxy `goproxy.cn` is used, which would, in effect, redirect HK users traffic.