### PR TITLE
cl: compileIdent class remove clCommandWithoutArgs

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -4515,3 +4515,45 @@ func main() {
 }
 `)
 }
+
+func TestClassFileMember(t *testing.T) {
+	gopClTestFile(t, `type Engine struct {
+}
+
+func (e *Engine) EnterPointerLock() {
+}
+
+func (e *Engine) SetEnable(b bool) {
+}
+
+
+func Engine() *Engine {
+	return &Engine{}
+}
+
+func Test() {
+	engine.setEnable true
+	engine.enterPointerLock
+}
+`, `package main
+
+type Engine struct {
+}
+
+func (e *Engine) EnterPointerLock() {
+}
+func (e *Engine) SetEnable(b bool) {
+}
+
+type Rect struct {
+}
+
+func (this *Rect) Engine() *Engine {
+	return &Engine{}
+}
+func (this *Rect) Test() {
+	this.Engine().SetEnable(true)
+	this.Engine().EnterPointerLock()
+}
+`, "Rect.gox")
+}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -98,7 +98,7 @@ func compileIdent(ctx *blockCtx, ident *ast.Ident, flags int) (obj *gox.PkgRef, 
 			sig := fn.Ancestor().Type().(*types.Signature)
 			if recv := sig.Recv(); recv != nil {
 				ctx.cb.Val(recv)
-				if compileMember(ctx, ident, name, flags) == nil { // class member object
+				if compileMember(ctx, ident, name, flags&^clCommandWithoutArgs) == nil { // class member object
 					return
 				}
 				ctx.cb.InternalStack().PopN(1)


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/1414