### PR TITLE
cl: fix compileCallArgs recover check

### DIFF
--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -964,3 +964,9 @@ const b = -1
 a := uint128(b)
 `)
 }
+
+func TestErrCompileFunc(t *testing.T) {
+	codeErrorTest(t, `./bar.gop:2:1: compile func printf("%+v\n", int32) error: unreachable`, `
+printf("%+v\n", int32)
+`)
+}

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -529,8 +529,13 @@ func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, inFlags int) {
 func compileCallArgs(fn *fnType, fnt types.Type, ctx *blockCtx, v *ast.CallExpr, ellipsis bool, flags gox.InstrFlags) (err error) {
 	n := ctx.cb.InternalStack().Len()
 	defer func() {
-		if v := recover(); v != nil {
-			err = v.(error)
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else {
+				src, pos := ctx.LoadExpr(v)
+				err = newCodeErrorf(&pos, "compile func %v error: %v", src, r)
+			}
 			ctx.cb.InternalStack().SetLen(n)
 		}
 	}()


### PR DESCRIPTION
check compile func internal error.
```
printf("%+v\n", int32)
```