### PR TITLE
chore: use the latest tag version and append it with "devel" to signify the binary installation via source code

### DIFF
--- a/cmd/make.go
+++ b/cmd/make.go
@@ -246,11 +246,17 @@ func getBuildDateTime() string {
 }
 
 func getBuildVer() string {
-	stdout, err := execCommand("git", "describe", "--tags")
+	latestTagCommit, err := execCommand("git", "rev-list", "--tags", "--max-count=1")
 	if err != nil {
 		return ""
 	}
-	return trimRight(stdout)
+
+	stdout, err := execCommand("git", "describe", "--tags", trimRight(latestTagCommit))
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s devel", trimRight(stdout))
 }
 
 func getGopBuildFlags() string {


### PR DESCRIPTION
`gop version` output incorrect tag version if the binary installation via source code as below:
```
➜  gop git:(main) gop version
gop v1.1.3-577-g4cf8b5e9 darwin/amd64
```
Now, This behavior will be adjusted to:
```
➜  gop git:(fix_version) gop version
gop v1.1.13 devel darwin/amd64
```