### PR TITLE
Pkg publish

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -50,3 +50,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WINGET_PKGS_PRIVATE_KEY: ${{ secrets.WINGET_PKGS_PRIVATE_KEY }}
+
+    - name: Upload deb/rpm to Fury.io
+      run: |
+        for file in dist/*.{deb,rpm}
+        do
+          echo "Uploading $file to Fury.io"
+          curl -sS -F package=@$file https://$FURY_TOKEN@push.fury.io/goplus/
+        done
+      env:
+        FURY_TOKEN: ${{ secrets.FURY_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,12 +68,25 @@ changelog:
       - "^test:"
 
 winget:
-  - name: gop
+  - name: goplus
     homepage: "https://goplus.org/"
     publisher: goplus
     publisher_url: https://github.com/goplus/gop
     publisher_support_url: "https://github.com/goplus/gop/issues/new"
     package_identifier: goplus.gop
+    path: "manifests/g/goplus/gop/{{.Version}}"
+    tags:
+      - golang
+      - go
+      - gop
+      - goplus
+      - programming
+      - language
+      - compiler
+      - interpreter
+      - data science
+      - engineering
+      - education
     short_description: The Go+ Programming Language
     description: |
       The Go+ programming language is designed for engineering, STEM education, and data science.
@@ -103,7 +116,7 @@ winget:
           branch: master
 
 nfpms:
-  - package_name: goplus-gop
+  - package_name: gop
     vendor: goplus
     homepage: https://goplus.org/
     maintainer: Li Jie <cpunion@gmail.com>
@@ -179,7 +192,7 @@ nfpms:
 
 snapcrafts:
   - id: gop
-    name: goplus
+    name: gop
     title: The Go+ Programming Language
     summary: The Go+ Programming Language
     description: |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,41 @@ For more details, see [Quick Start](doc/docs.md).
 
 ## How to install
 
+### on Windows
+
+```sh
+winget install goplus
+```
+
+Or
+
+```sh
+winget install goplus.gop
+```
+
+### on Debian/Ubuntu
+
+```sh
+sudo bash -c ' echo "deb [trusted=yes] https://apt.fury.io/goplus/ /" > /etc/apt/sources.list.d/goplus.list'
+sudo apt update
+sudo apt install gop
+```
+
+### on RedHat/CentOS/Fedora
+
+```sh
+sudo bash -c 'echo -e "[goplus]\nname=Go+ Repo\nbaseurl=https://yum.fury.io/goplus/\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/goplus.repo'
+sudo yum install gop
+```
+
+### on macOS/Linux(Homebrew)
+
+Install via [brew](https://brew.sh/)
+
+```sh
+$ brew install goplus
+```
+
 ### from source code
 
 For now, we suggest you install Go+ from source code.
@@ -62,14 +97,6 @@ cd gop
 # On Windows run:
 all.bat
 ```
-
-### on macOS/Linux
-
-Install via [brew](https://brew.sh/)
-```sh
-$ brew install goplus
-```
-
 
 ## Go+ Applications
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ winget install goplus.gop
 ### on Debian/Ubuntu
 
 ```sh
-sudo bash -c ' echo "deb [trusted=yes] https://apt.fury.io/goplus/ /" > /etc/apt/sources.list.d/goplus.list'
+sudo bash -c ' echo "deb [trusted=yes] https://pkgs.goplus.org/apt/ /" > /etc/apt/sources.list.d/goplus.list'
 sudo apt update
 sudo apt install gop
 ```
@@ -70,7 +70,7 @@ sudo apt install gop
 ### on RedHat/CentOS/Fedora
 
 ```sh
-sudo bash -c 'echo -e "[goplus]\nname=Go+ Repo\nbaseurl=https://yum.fury.io/goplus/\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/goplus.repo'
+sudo bash -c 'echo -e "[goplus]\nname=Go+ Repo\nbaseurl=https://pkgs.goplus.org/yum/\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/goplus.repo'
 sudo yum install gop
 ```
 


### PR DESCRIPTION
* rename winget package name to goplus to supports `winget install goplus`, also supports `winget install goplus.gop`
* rename deb/rpm/snapcraft package name to gop
* publish deb/rpm to fury.io
* update installation docs