### PR TITLE
chore: adjust github enhancement template to make as more logical

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -8,14 +8,6 @@ body:
         ⚠️ Make sure to browse the opened and closed issues before submit your issue.
 
   - type: textarea
-    id: proposal
-    attributes:
-      label: Proposal
-      description: Write your feature request in the form of a proposal to be considered for implementation.
-    validations:
-      required: true
-
-  - type: textarea
     id: background
     attributes:
       label: Background
@@ -28,5 +20,13 @@ body:
     attributes:
       label: Workarounds
       description: Are there any current workarounds that you're using that others in similar positions should know about?
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Write your feature request in the form of a proposal to be considered for implementation.
     validations:
       required: true


### PR DESCRIPTION
The current display looks strange. it shows as `proposal > background > workaround`, for example:  https://github.com/goplus/gop/issues/1702

Adjust it as:
* `background > workaround > proposal`
* make workaround as optional