### PR TITLE
feat(gengo): support convert go+ files into go code

### DIFF
--- a/cmd/internal/gengo/go.go
+++ b/cmd/internal/gengo/go.go
@@ -33,15 +33,15 @@ import (
 
 // gop go
 var Cmd = &base.Command{
-	UsageLine: "gop go [-v] [packages]",
-	Short:     "Convert Go+ packages into Go packages",
+	UsageLine: "gop go [-v] [packages|files]",
+	Short:     "Convert Go+ code into Go code",
 }
 
 var (
 	flag                 = &Cmd.Flag
 	flagVerbose          = flag.Bool("v", false, "print verbose information")
 	flagCheckMode        = flag.Bool("t", false, "do check syntax only, no generate gop_autogen.go")
-	flagSingleMode       = flag.Bool("s", false, "run in single file mode")
+	flagSingleMode       = flag.Bool("s", false, "run in single file mode for package")
 	flagIgnoreNotatedErr = flag.Bool(
 		"ignore-notated-error", false, "ignore notated errors, only available together with -t (check mode)")
 )
@@ -88,6 +88,8 @@ func runCmd(cmd *base.Command, args []string) {
 			_, _, err = gop.GenGoEx(v.Dir, conf, true, flags)
 		case *gopprojs.PkgPathProj:
 			_, _, err = gop.GenGoPkgPathEx("", v.Path, conf, true, flags)
+		case *gopprojs.FilesProj:
+			_, err = gop.GenGoFiles("", v.Files, conf)
 		default:
 			log.Panicln("`gop go` doesn't support", reflect.TypeOf(v))
 		}


### PR DESCRIPTION
This PR primarily addresses the following two issues.

* `gop go` doesn't support convert go+ files into go, fox example:

```shell
➜  101-Hello-world git:(main) ✗ gop go -v hello-1.gop
2024/02/02 16:53:22 SetDebug: import=true, match=true, instr=true
2024/02/02 16:53:22 `gop go` doesn't support *gopprojs.FilesProj
panic: `gop go` doesn't support *gopprojs.FilesProj


goroutine 1 [running]:
log.Panicln({0xc000205e28?, 0xc0000ba060?, 0x1d045b8?})
	/opt/hostedtoolcache/go/1.21.6/x64/src/log/log.go:446 +0x5a
github.com/goplus/gop/cmd/internal/gengo.runCmd(0xc0000d8000?, {0xc0000ba060?, 0x0?, 0xc00006a688?})
	/home/runner/work/gop/gop/cmd/internal/gengo/go.go:92 +0x365
main.main()
	/home/runner/work/gop/gop/cmd/gop/main.go:113 +0x4b3
```

* The original single file mode flag `-s` seems aim to work in package mode, so i update the description accordingly:
```shell
➜  101-Hello-world git:(main) ✗ ll
total 24
drwxr-xr-x   5 jicarl  staff   160 Feb  2 16:58 .
drwxr-xr-x  63 jicarl  staff  2016 Feb  2 16:45 ..
-rw-r--r--   1 jicarl  staff   358 Dec 15  2021 hello-1.gop
-rw-r--r--   1 jicarl  staff   469 Dec 15  2021 hello-2.gop
-rw-r--r--   1 jicarl  staff   776 Dec 15  2021 hello-3.gop
➜  101-Hello-world git:(main) ✗ gop go -s .
Single file mode
GenGo hello-1.gop ...
GenGo hello-2.gop ...
GenGo hello-3.gop ...
➜  101-Hello-world git:(main) ✗
```
