### PR TITLE
ci: skip publish prerelease

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -34,6 +34,15 @@ jobs:
           echo "TAG: $tag"
           exit 1
         fi
+    
+    - name: Check pre-release
+      run: |
+        version=$(cat VERSION)
+        # check stable version format x.x.x
+        if ! [[ $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "This is a pre-release"
+          echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+        fi
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -53,6 +62,7 @@ jobs:
         WINGET_PKGS_PRIVATE_KEY: ${{ secrets.WINGET_PKGS_PRIVATE_KEY }}
 
     - name: Upload deb/rpm to Fury.io
+      if: env.IS_PRERELEASE != 'true'
       run: |
         for file in dist/*.{deb,rpm}
         do

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,7 +94,7 @@ winget:
       - For STEM education: studying an engineering language that can be used for work in the future.
       - For data science: communicating with engineers in the same language.
     license: Apache-2.0
-    skip_upload: false
+    skip_upload: auto
     release_notes: "{{.Changelog}}"
     release_notes_url: "https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }}/gop/releases/tag/v{{.Version}}"
     dependencies:
@@ -109,7 +109,7 @@ winget:
         private_key: "{{ .Env.WINGET_PKGS_PRIVATE_KEY }}"
       pull_request:
         enabled: true
-        draft: false
+        draft: true
         base:
           owner: microsoft
           name: winget-pkgs


### PR DESCRIPTION
* Skip publish prerelease version to winget/fury.io because winget/yum/apt are incompatible with SemVer.
* Enable winget PR draft