### PR TITLE
parser: fix string extra check

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1705,7 +1705,7 @@ func (p *parser) parseOperand(lhs, allowTuple, allowCmd bool) (x ast.Expr, isTup
 
 	case token.STRING, token.CSTRING, token.INT, token.FLOAT, token.IMAG, token.CHAR, token.RAT:
 		bl := &ast.BasicLit{ValuePos: p.pos, Kind: p.tok, Value: p.lit}
-		if p.tok == token.STRING {
+		if p.tok == token.STRING && len(p.lit) > 1 {
 			bl.Extra = p.stringLit(p.pos, p.lit)
 		}
 		x = bl

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -545,4 +545,9 @@ println "$a${b}"
 `, "/foo/bar.gop:2:10: invalid $ expression: neither `${ ... }` nor `$$`", ``)
 }
 
+func TestErrStringLiteral(t *testing.T) {
+	testErrCode(t, `run "
+`, `/foo/bar.gop:1:5: string literal not terminated`, ``)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix parser panic 
```
run "
```
```
panic: runtime error: slice bounds out of range [1:0] [recovered]
	panic: runtime error: slice bounds out of range [1:0]
goroutine 1 [running]:
github.com/goplus/gop/parser.parseFile.func1()
	/Users/vfc/goplus/gop/parser/interface.go:96 +0x1f2
panic({0x1680080?, 0xc0000c81c8?})
```
fixed to
```
bug.gop:1:5: string literal not terminated
```