### PR TITLE
update:correct anonymous overloaded function naming

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1088,6 +1088,7 @@ func preloadFile(p *gogen.Package, ctx *blockCtx, f *ast.File, goFile string, ge
 				case *ast.FuncLit:
 					checkOverloadFunc(d)
 					name1 := overloadFuncName(name.Name, idx)
+					onames = append(onames, "") // const Gopo_xxx = "xxxInt,,xxxFloat"
 					ctx.lbinames = append(ctx.lbinames, name1)
 					preloadFuncDecl(&ast.FuncDecl{
 						Doc:  d.Doc,

--- a/cl/compile_gop_test.go
+++ b/cl/compile_gop_test.go
@@ -376,6 +376,46 @@ func main() {
 `)
 }
 
+func TestOverloadFunc3(t *testing.T) {
+	gopClTest(t, `
+func addInt(a, b int) int {
+	return a + b
+}
+
+func addFloat(a, b float64) float64 {
+	return a * b
+}
+
+func add = (
+	func (a,b string) string { return a + b }
+	addInt
+	addFloat
+)
+
+println add(100, 7)
+println add(1.2, 3.14)
+`, `package main
+
+import "fmt"
+
+const Gopo_add = ",addInt,addFloat"
+
+func add__0(a string, b string) string {
+	return a + b
+}
+func addInt(a int, b int) int {
+	return a + b
+}
+func addFloat(a float64, b float64) float64 {
+	return a * b
+}
+func main() {
+	fmt.Println(addInt(100, 7))
+	fmt.Println(addFloat(1.2, 3.14))
+}
+`)
+}
+
 func TestOverload(t *testing.T) {
 	gopClTest(t, `
 import "github.com/goplus/gop/cl/internal/overload/foo"


### PR DESCRIPTION
- [x] correct compiled overloaded function declaration when have a anonymous overloaded function

```go
// origin.gop
func MulInt(a,b int) int  {
	return a * b
}
func MulFloat(a,b float64) float64  {
	return a * b
}
func Mul = (
	func(a string,b string){}
	MulInt
	MulFloat
)
```
The overloaded function declaration generated in the previous version lacks the location of the anonymous overloaded function.
```go
// before autogen.go
const _ = true
const Gopo_Mul = "MulInt,MulFloat"

func Mul__0(a string, b string) {
}

func MulInt(a int, b int) int {
	return a * b
}

func MulFloat(a float64, b float64) float64 {
	return a * b
}
```
```go
// current autogen.go
const _ = true
const Gopo_Mul = ",MulInt,MulFloat"
....
```