### PR TITLE
ci: update workflow to trigger on pushes and PRs to any branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,11 @@ name: Go+ CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - "*"
   pull_request:
-    branches: [ main ]
+    branches:
+    - "*"
 
 jobs:
   Check:


### PR DESCRIPTION
This update ensures that Go+ CI is triggered by pushes and pull requests to all branches, providing comprehensive coverage across the repository. This change is particularly beneficial for enabling GitHub Actions in forks, facilitating a more seamless development and testing process.