### PR TITLE
docker: align image tags with GoReleaser artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,7 +67,7 @@ changelog:
 dockers:
   - goarch: "386"
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-i386
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-386
     use: buildx
     build_flag_templates:
       - --platform=linux/386
@@ -76,7 +76,7 @@ dockers:
       - ./
   - goarch: amd64
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-x86_64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-amd64
     use: buildx
     build_flag_templates:
       - --platform=linux/amd64
@@ -85,7 +85,7 @@ dockers:
       - ./
   - goarch: arm64
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-arm64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-arm64
     use: buildx
     build_flag_templates:
       - --platform=linux/arm64
@@ -94,28 +94,28 @@ dockers:
       - ./
 
 docker_manifests:
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}
+  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-i386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-x86_64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-arm64
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Major }}.{{ .Minor }}
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-386
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-amd64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-arm64
+  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Major }}.{{ .Minor }}
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-i386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-x86_64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-arm64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-386
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-amd64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-arm64
     skip_push: auto
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Major }}
+  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Major }}
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-i386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-x86_64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-arm64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-386
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-amd64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-arm64
     skip_push: auto
   - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:latest
     image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-i386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-x86_64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:v{{ .Version }}-arm64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-386
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-amd64
+      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/gop" }}:{{ .Version }}-arm64
     skip_push: auto
 
 winget:


### PR DESCRIPTION
Following the changes introduced in #1838, this commit updates Docker image and manifest tags to align with the GoReleaser artifact naming conventions. The changes are as follows:

- Image tags have been updated from "v1.2.3-i386" to "1.2.3-386", from "v1.2.3-x86_64" to "1.2.3-amd64", "v1.2.3-arm64" to "1.2.3-arm64".
- The version prefix "v" has been removed from the image manifest tags, changing "v1.2.3" to "1.2.3", "v1.2" to "1.2", and "v1" to "1".

---

Should we keep the `v` prefix? I referred to the tag style of `docker.io/library/golang` and removed the `v` prefix. (See: https://hub.docker.com/_/golang/tags?name=-alpine3.19)

/cc @xushiwei @cpunion 