### PR TITLE
ci(go.yml): update macOS version in Test job to "macos-latest"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,10 @@ jobs:
   Test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11]
+        os:
+        - ubuntu-latest
+        - windows-latest
+        - macos-latest
         go:
         - 1.18.x
         - 1.19.x


### PR DESCRIPTION
This commit updates .github/workflows/go.yml by changing the macOS version in the testing matrix from "macos-11" to "macos-latest". The change is necessary due to the deprecation of the "macos-11" label, as mentioned in the GitHub Docs[^1]. According to the docs, the "macos-11" label will no longer be available after 2024-06-28.

[^1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories