### PR TITLE
ast: fix (*ast.File).End check shadow no entry

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1156,8 +1156,12 @@ func (f *File) Pos() token.Pos {
 
 // End returns position of first character immediately after the node.
 func (f *File) End() token.Pos {
-	if n := len(f.Decls); n > 0 {
-		return f.Decls[n-1].End()
+	for n := len(f.Decls) - 1; n >= 0; n-- {
+		d := f.Decls[n]
+		if fn, ok := d.(*FuncDecl); ok && fn.Shadow && fn != f.ShadowEntry {
+			continue
+		}
+		return d.End()
 	}
 	return f.Name.End()
 }

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/goplus/gogen/cpackages"
 	"github.com/goplus/gogen/packages"
 	"github.com/goplus/gop/ast"
+	"github.com/goplus/gop/parser"
 	"github.com/goplus/gop/token"
 	"github.com/goplus/mod/modfile"
 )
@@ -685,6 +686,18 @@ func testPanic(t *testing.T, panicMsg string, doPanic func()) {
 		}()
 		doPanic()
 	})
+}
+
+func TestClassFileEnd(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "get.yap", `json {"id": ${id} }`, parser.ParseGoPlusClass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Decls = append(f.Decls, astFnClassfname(&gmxClass{clsfile: "get"}))
+	if f.End() != f.ShadowEntry.End() {
+		t.Fatal("class file end not shadow entry")
+	}
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix (*ast.File).End bad result if classfile add shadow func Classfname.

example `get.yap` ast.File.End return  last shadow func Classfname.End()