### PR TITLE
cl: keep stmt comments

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -369,6 +369,7 @@ type blockCtx struct {
 	lookups    []gogen.PkgRef
 	clookups   []cpackages.PkgRef
 	tlookup    *typeParamLookup
+	cmap       ast.CommentMap
 	c2goBase   string // default is `github.com/goplus/`
 	relBaseDir string
 
@@ -567,6 +568,7 @@ func NewPackage(pkgPath string, pkg *ast.Package, conf *Config) (p *gogen.Packag
 			pkg: p, pkgCtx: ctx, cb: p.CB(), relBaseDir: relBaseDir, fileScope: fileScope,
 			fileLine: fileLine, isClass: f.IsClass, rec: rec,
 			c2goBase: c2goBase(conf.C2goBase), imports: make(map[string]pkgImp), isGopFile: true,
+			cmap: ast.NewCommentMap(fset, f.File, f.Comments),
 		}
 		if rec := ctx.rec; rec != nil {
 			rec.Scope(f.File, fileScope)
@@ -588,6 +590,7 @@ func NewPackage(pkgPath string, pkg *ast.Package, conf *Config) (p *gogen.Packag
 		ctx := &blockCtx{
 			pkg: p, pkgCtx: ctx, cb: p.CB(), relBaseDir: relBaseDir,
 			imports: make(map[string]pkgImp),
+			cmap:    ast.NewCommentMap(fset, f, f.Comments),
 		}
 		preloadFile(p, ctx, f, skippingGoFile, false)
 	}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -4078,6 +4078,44 @@ func demo() {
 `)
 }
 
+func TestCommentStmt(t *testing.T) {
+	gopClTestEx(t, gblConfLine, "main", `
+// doc func foo
+func foo(a int) {
+	// this is a comment one.1
+	// this is a comment one.2
+	println(a)
+	// this is a comment two.1
+	// this is a comment two.2
+	println(a+1)
+}
+
+// this is a comment three
+foo(2)
+`, `package main
+
+import "fmt"
+//line /foo/bar.gop:2:1
+// doc func foo
+func foo(a int) {
+//line /foo/bar.gop:6:1
+	// this is a comment one.1
+	// this is a comment one.2
+	fmt.Println(a)
+//line /foo/bar.gop:9:1
+	// this is a comment two.1
+	// this is a comment two.2
+	fmt.Println(a + 1)
+}
+//line /foo/bar.gop:12
+// this is a comment three
+func main() {
+//line /foo/bar.gop:13:1
+	foo(2)
+}
+`)
+}
+
 func TestForPhraseScope(t *testing.T) {
 	gopClTest(t, `sum := 0
 for x <- [1, 3, 5, 7, 11, 13, 17] {


### PR DESCRIPTION
Refer #1864 

This PR only fixes a portion of the scenarios, and there are still other TODO items that need to be handled, like:

* go+ overload function comments
* keep comments when no need add fileLine
* do format for the generated code to adheres to the standard Go coding style 

I will continue to follow up on these tasks in separate PRs.
