### PR TITLE
test: make cmd/TestInstallInNonGitRepo not affected by actual major.minor versions

### DIFF
--- a/cmd/make_test.go
+++ b/cmd/make_test.go
@@ -6,12 +6,15 @@ package make_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/goplus/gop/env"
 )
 
 const (
@@ -307,7 +310,7 @@ func TestInstallInNonGitRepo(t *testing.T) {
 	})
 
 	t.Run("install with VERSION file", func(t *testing.T) {
-		version := "v1.3.98"
+		version := fmt.Sprintf("v%s.65535", env.MainVersion)
 		// Create VERSION file
 		if err := os.WriteFile(versionFile, []byte(version), 0644); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This follows up on #1930.

For https://github.com/goplus/gop/actions/runs/9927782432/job/27423172805#step:4:27

```
=== RUN   TestInstallInNonGitRepo/install_with_VERSION_file
    make_test.go:324: Failed: exit status 2, output: panic: gop/env: [FATAL] Invalid buildVersion: v1.2.98
        
        goroutine 1 [running]:
        github.com/goplus/gop/env.initEnv()
        	/home/runner/work/gop/gop/env/version.go:47 +0x8a
        github.com/goplus/gop/env.init.0()
        	/home/runner/work/gop/gop/env/version.go:38 +0xf
```