### PR TITLE
cl: fix compileCompositeLitEx struct for sliceLit/mapLit

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -4193,3 +4193,61 @@ func main() {
 }
 `)
 }
+
+func TestCompositeLitStruct(t *testing.T) {
+	gopClTest(t, `
+type T struct {
+	s  []any
+	m  map[any]any
+	fn func(int) int
+}
+
+echo &T{[10, 3.14, 200], {10: "A", 3.14: "B", 200: "C"}, (x => x)}
+echo &T{s: [10, 3.14, 200], m: {10: "A", 3.14: "B", 200: "C"}, fn: (x => x)}
+`, `package main
+
+import "fmt"
+
+type T struct {
+	s  []interface{}
+	m  map[interface{}]interface{}
+	fn func(int) int
+}
+
+func main() {
+	fmt.Println(&T{[]interface{}{10, 3.14, 200}, map[interface{}]interface{}{10: "A", 3.14: "B", 200: "C"}, func(x int) int {
+		return x
+	}})
+	fmt.Println(&T{s: []interface{}{10, 3.14, 200}, m: map[interface{}]interface{}{10: "A", 3.14: "B", 200: "C"}, fn: func(x int) int {
+		return x
+	}})
+}
+`)
+}
+
+func TestCompositeLitEx(t *testing.T) {
+	gopClTest(t, `
+var a [][]any = {[10, 3.14, 200], [100, 200]}
+var m map[any][]any = {10: [10, 3.14, 200]}
+var f map[any]func(int) int = {10: x => x}
+
+echo a
+echo m
+echo f
+`, `package main
+
+import "fmt"
+
+var a [][]interface{} = [][]interface{}{[]interface{}{10, 3.14, 200}, []interface{}{100, 200}}
+var m map[interface{}][]interface{} = map[interface{}][]interface{}{10: []interface{}{10, 3.14, 200}}
+var f map[interface{}]func(int) int = map[interface{}]func(int) int{10: func(x int) int {
+	return x
+}}
+
+func main() {
+	fmt.Println(a)
+	fmt.Println(m)
+	fmt.Println(f)
+}
+`)
+}

--- a/cl/error_msg_test.go
+++ b/cl/error_msg_test.go
@@ -1071,3 +1071,30 @@ func (foo).++ = (
 )
 `)
 }
+
+func TestCompositeLitError(t *testing.T) {
+	codeErrorTest(t, `bar.gop:2:22: cannot use 3.14 (type untyped float) as type int in slice literal`, `
+var a [][]int = {[10,3.14,200],[100,200]}
+echo a
+`)
+	codeErrorTest(t, `bar.gop:2:17: cannot use lambda literal as type int in assignment`, `
+var a []int = {(x => x)}
+echo a
+`)
+	codeErrorTest(t, `bar.gop:2:35: cannot use x (type int) as type string in return argument`, `
+var a []func(int) string = {(x => x)}
+echo a
+`)
+	codeErrorTest(t, `bar.gop:2:27: cannot use lambda literal as type int in assignment to "A"`, `
+var a map[any]int = {"A": x => x}
+`)
+	codeErrorTest(t, `bar.gop:2:45: cannot use x (type int) as type string in return argument`, `
+var a map[any]func(int) string = {"A": x => x}
+`)
+	codeErrorTest(t, `bar.gop:2:24: cannot use lambda literal as type int in field value`, `
+var a = struct{v int}{(x => x)}
+`)
+	codeErrorTest(t, `bar.gop:2:27: cannot use lambda literal as type int in field value to v`, `
+var a = struct{v int}{v: (x => x)}
+`)
+}

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -295,7 +295,7 @@ func compileAssignStmt(ctx *blockCtx, expr *ast.AssignStmt) {
 		compileExprLHS(ctx, lhs)
 	}
 	for i, rhs := range expr.Rhs {
-		switch e := rhs.(type) {
+		switch e := unparen(rhs).(type) {
 		case *ast.LambdaExpr, *ast.LambdaExpr2:
 			if len(expr.Lhs) == 1 && len(expr.Rhs) == 1 {
 				typ := ctx.cb.Get(-1).Type.(interface{ Elem() types.Type }).Elem()


### PR DESCRIPTION
compileCompositeLitEx
- struct
```
type T struct {
	s  []any
	m  map[any]any
	fn func(int) int
}
echo &T{[10, 3.14, 200], {10: "A", 3.14: "B", 200: "C"}, (x => x)}
echo &T{s: [10, 3.14, 200], m: {10: "A", 3.14: "B", 200: "C"}, fn: (x => x)}
```
- slice/map
```
var a [][]any = {[10, 3.14, 200], [100, 200]}
var m map[any][]any = {10: [10, 3.14, 200]}
var f map[any]func(int) int = {10: x => x}
```