### PR TITLE
Introducing Go+ Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 [![Coverage Status](https://codecov.io/gh/goplus/gop/branch/main/graph/badge.svg)](https://codecov.io/gh/goplus/gop)
 [![GitHub release](https://img.shields.io/github/v/tag/goplus/gop.svg?label=release)](https://github.com/goplus/gop/releases)
 [![Discord](https://img.shields.io/badge/Discord-online-success.svg?logo=discord&logoColor=white)](https://discord.com/invite/mYjWCJDcAr)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Go%2B%20Guru-006BFF)](https://gurubase.io/g/goplus)
 
 </div>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Go+ Guru](https://gurubase.io/g/goplus) to Gurubase. Go+ Guru uses the data from this repo and data from the [docs](https://tutorial.goplus.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Go+ Guru", which highlights that Go+ now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Go+ Guru in Gurubase, just let me know that's totally fine.
