### PR TITLE
fix(Dockerfile): extract artifacts from tarball when using GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,7 @@ dockers:
     build_flag_templates:
       - --platform=linux/386
       - --build-arg=USE_GORELEASER_ARTIFACTS=1
+      - --build-arg=GORELEASER_ARTIFACTS_TARBALL=./.dist/{{.ProjectName}}{{.Version}}.linux-386.tar.gz
     extra_files:
       - ./
   - goarch: amd64
@@ -60,6 +61,7 @@ dockers:
     build_flag_templates:
       - --platform=linux/amd64
       - --build-arg=USE_GORELEASER_ARTIFACTS=1
+      - --build-arg=GORELEASER_ARTIFACTS_TARBALL=./.dist/{{.ProjectName}}{{.Version}}.linux-amd64.tar.gz
     extra_files:
       - ./
   - goarch: arm64
@@ -69,6 +71,7 @@ dockers:
     build_flag_templates:
       - --platform=linux/arm64
       - --build-arg=USE_GORELEASER_ARTIFACTS=1
+      - --build-arg=GORELEASER_ARTIFACTS_TARBALL=./.dist/{{.ProjectName}}{{.Version}}.linux-arm64.tar.gz
     extra_files:
       - ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,18 @@ ARG BASE_IMAGE=golang:1.22-bookworm
 
 FROM $BASE_IMAGE AS build
 ARG USE_GORELEASER_ARTIFACTS=0
+ARG GORELEASER_ARTIFACTS_TARBALL
 WORKDIR /usr/local/src/gop
 COPY . .
 ENV GOPROOT=/usr/local/gop
 RUN set -eux; \
-	mkdir -p $GOPROOT/bin; \
-	git ls-tree --full-tree --name-only -r HEAD | grep -vE "^\." | xargs -I {} cp --parents {} $GOPROOT/; \
+	mkdir $GOPROOT; \
 	if [ $USE_GORELEASER_ARTIFACTS -eq 1 ]; then \
-		GOARCH=$(go env GOARCH); \
-		BIN_DIR_SUFFIX=linux_$GOARCH; \
-		[ $GOARCH = "amd64" ] && BIN_DIR_SUFFIX=${BIN_DIR_SUFFIX}_v1; \
-		[ $GOARCH = "arm" ] && BIN_DIR_SUFFIX=${BIN_DIR_SUFFIX}_$(go env GOARM | cut -d , -f 1); \
-		cp .dist/gop_$BIN_DIR_SUFFIX/bin/gop $GOPROOT/bin/; \
+		tar -xzf "${GORELEASER_ARTIFACTS_TARBALL}" -C $GOPROOT; \
 	else \
+		git ls-tree --full-tree --name-only -r HEAD | grep -vE "^\." | xargs -I {} cp --parents {} $GOPROOT/; \
 		./all.bash; \
-		cp bin/gop $GOPROOT/bin/; \
+		mv bin $GOPROOT/; \
 	fi
 
 FROM $BASE_IMAGE


### PR DESCRIPTION
According to GoReleaser docs, the directory names inside dist have no guarantee of remaining the same across different GoReleaser versions[^1]. Therefore, we extract from tarballs instead of using those directories directly.

[^1]: https://goreleaser.com/customization/builds/#a-note-about-directory-names-inside-dist