### PR TITLE
refactor(x/typesutil.Checker): handle `gogen.BoundTypeError` with fallback error logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/fsnotify/fsnotify v1.8.0
-	github.com/goplus/gogen v1.16.6
+	github.com/goplus/gogen v1.16.7
 	github.com/goplus/llgo v0.10.0
 	github.com/goplus/mod v0.13.17
 	github.com/qiniu/x v1.13.12

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/goplus/gogen v1.16.6 h1:Zwv18HoTbPDk8s2ajxgVeqZE5i4/GMV722KHl6GS8Yk=
-github.com/goplus/gogen v1.16.6/go.mod h1:6TQYbabXDF9LCdDkOOzHmfg1R4ENfXQ3XpHa9RhTSD8=
+github.com/goplus/gogen v1.16.7 h1:OVN6byjWVtzs4plS7q80h747Jh8G7J+VUPN0L9YWQ68=
+github.com/goplus/gogen v1.16.7/go.mod h1:6TQYbabXDF9LCdDkOOzHmfg1R4ENfXQ3XpHa9RhTSD8=
 github.com/goplus/llgo v0.10.0 h1:s3U3cnO3cploF1xCCJleAb16NQFAmHxdUmdrNhRH3hY=
 github.com/goplus/llgo v0.10.0/go.mod h1:YfOHsT/g3lc9b4GclLj812YzdSsJr0kd3CCB830TqHE=
 github.com/goplus/mod v0.13.17 h1:aWp14xosENrh7t0/0qcIejDmQEiTgI3ou2+KoLDlSlE=

--- a/x/typesutil/check.go
+++ b/x/typesutil/check.go
@@ -163,6 +163,8 @@ func (p *Checker) Files(goFiles []*goast.File, gopFiles []*ast.File) (err error)
 				}
 			} else if ce, ok := convErr(fset, err); ok {
 				onErr(ce)
+			} else {
+				onErr(err)
 			}
 		}
 		if debugPrintErr {
@@ -245,6 +247,9 @@ func convErr(fset *token.FileSet, e error) (ret types.Error, ok bool) {
 		typesutil.SetErrorGo116(&ret, 0, ret.Pos, end)
 	case *gogen.ImportError:
 		ret.Pos, ret.Msg = v.Pos, v.Err.Error()
+		typesutil.SetErrorGo116(&ret, 0, v.Pos, v.Pos)
+	case *gogen.BoundTypeError:
+		ret.Pos, ret.Msg = v.Pos, v.Error()
 		typesutil.SetErrorGo116(&ret, 0, v.Pos, v.Pos)
 	default:
 		return

--- a/x/typesutil/check_test.go
+++ b/x/typesutil/check_test.go
@@ -185,6 +185,13 @@ var i int = "hello"
 	if err == nil {
 		t.Fatal("no error")
 	}
+	_, _, err = checkFiles(fset, "main.gop", `
+var nums []int
+nums = append(nums, "NaN")
+`, "", "", "", "")
+	if err == nil {
+		t.Fatal("no error")
+	}
 }
 
 func TestBadFile(t *testing.T) {


### PR DESCRIPTION
Updates goplus/builder#1378