### PR TITLE
make: support Go1.24

### DIFF
--- a/tool/imp.go
+++ b/tool/imp.go
@@ -86,6 +86,7 @@ func (p *Importer) CacheFile() string {
 
 	fname := ""
 	h := sha256.New()
+	io.WriteString(h, runtime.Version())
 	if root := p.mod.Root(); root != "" {
 		io.WriteString(h, root)
 		fname = filepath.Base(root)


### PR DESCRIPTION
- make.go check go1.24 use go.work mode
- importer cache file hash add runtime.Version()