### PR TITLE
Support using the go keyword as the struct type name

### DIFF
--- a/cl/classfile.go
+++ b/cl/classfile.go
@@ -217,8 +217,8 @@ func exClassNameAndExt(file string, keepMain bool) (name, clsfile, ext string) {
 			if !keepMain {
 				name = "_main"
 			}
-		case "init":
-			name = "_init"
+		case "init", "go":
+			name = "_" + name
 		}
 	}
 	return


### PR DESCRIPTION
fix issue: https://github.com/goplus/gop/issues/2327