### PR TITLE
fix(compile): ensure valid Rparen and NoParenEnd in CallExpr

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -477,7 +477,11 @@ func (x *CallExpr) End() token.Pos {
 	if x.NoParenEnd != token.NoPos {
 		return x.NoParenEnd
 	}
-	return x.Rparen + 1
+	if x.Rparen.IsValid() {
+		return x.Rparen + 1
+	}
+
+	return x.Fun.End()
 }
 
 // IsCommand returns if a CallExpr is a command style CallExpr or not.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -477,11 +477,7 @@ func (x *CallExpr) End() token.Pos {
 	if x.NoParenEnd != token.NoPos {
 		return x.NoParenEnd
 	}
-	if x.Rparen.IsValid() {
-		return x.Rparen + 1
-	}
-
-	return x.Fun.End()
+	return x.Rparen + 1
 }
 
 // IsCommand returns if a CallExpr is a command style CallExpr or not.

--- a/cl/compile_spx_test.go
+++ b/cl/compile_spx_test.go
@@ -101,6 +101,12 @@ Greem.t4spx:1:1: cannot use  (type *Greem) as type github.com/goplus/gop/cl/inte
 )`,
 		"/foo/Greem.t4spx": ``,
 	})
+
+	gopSpxErrorTestMap(t, `Game.t4gmx:1:9: cannot use backdropName (type string) as type error in assignment`, map[string][]string{
+		"/foo": {"Game.t4gmx"},
+	}, map[string]string{
+		"/foo/Game.t4gmx": `println backdropName!`,
+	})
 }
 
 func TestSpxBasic(t *testing.T) {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -664,9 +664,10 @@ func (p *fnType) initFuncs(base int, funcs []types.Object, typeAsParams bool) {
 }
 
 func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, inFlags int) {
-	if !v.NoParenEnd.IsValid() && !v.Rparen.IsValid() {
-		panic("unexpected invalid Rparen and NoParenEnd in CallExpr")
-	}
+	// If you need to confirm the callExpr format, you can turn on
+	// if !v.NoParenEnd.IsValid() && !v.Rparen.IsValid() {
+	// 	panic("unexpected invalid Rparen and NoParenEnd in CallExpr")
+	// }
 	var ifn *ast.Ident
 	switch fn := v.Fun.(type) {
 	case *ast.Ident:

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -1660,7 +1660,7 @@ func compileErrWrapExpr(ctx *blockCtx, v *ast.ErrWrapExpr, inFlags int) {
 	expr := v.X
 	switch expr.(type) {
 	case *ast.Ident, *ast.SelectorExpr:
-		expr = &ast.CallExpr{Fun: expr, NoParenEnd: v.X.End()}
+		expr = &ast.CallExpr{Fun: expr, NoParenEnd: expr.End()}
 	}
 	compileExpr(ctx, expr, inFlags)
 	x := cb.InternalStack().Pop()

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -664,6 +664,9 @@ func (p *fnType) initFuncs(base int, funcs []types.Object, typeAsParams bool) {
 }
 
 func compileCallExpr(ctx *blockCtx, v *ast.CallExpr, inFlags int) {
+	if !v.NoParenEnd.IsValid() && !v.Rparen.IsValid() {
+		panic("unexpected invalid Rparen and NoParenEnd in CallExpr")
+	}
 	var ifn *ast.Ident
 	switch fn := v.Fun.(type) {
 	case *ast.Ident:
@@ -1657,7 +1660,7 @@ func compileErrWrapExpr(ctx *blockCtx, v *ast.ErrWrapExpr, inFlags int) {
 	expr := v.X
 	switch expr.(type) {
 	case *ast.Ident, *ast.SelectorExpr:
-		expr = &ast.CallExpr{Fun: expr}
+		expr = &ast.CallExpr{Fun: expr, NoParenEnd: v.X.End()}
 	}
 	compileExpr(ctx, expr, inFlags)
 	x := cb.InternalStack().Pop()

--- a/cl/internal/spx4/game.go
+++ b/cl/internal/spx4/game.go
@@ -54,9 +54,7 @@ func (p *MyGame) Broadcast__1(msg string, wait bool) {
 func (p *MyGame) Broadcast__2(msg string, data any, wait bool) {
 }
 
-type BackdropName = string
-
-func (p *MyGame) BackdropName() BackdropName {
+func (p *MyGame) BackdropName() string {
 	return ""
 }
 

--- a/cl/internal/spx4/game.go
+++ b/cl/internal/spx4/game.go
@@ -54,6 +54,12 @@ func (p *MyGame) Broadcast__1(msg string, wait bool) {
 func (p *MyGame) Broadcast__2(msg string, data any, wait bool) {
 }
 
+type BackdropName = string
+
+func (p *MyGame) BackdropName() BackdropName {
+	return ""
+}
+
 func (p *MyGame) Play(media string, wait ...bool) {
 }
 

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -904,7 +904,7 @@ func compileBranchStmt(ctx *blockCtx, v *ast.BranchStmt) {
 		compileCallExpr(ctx, &ast.CallExpr{
 			Fun:        &ast.Ident{NamePos: v.TokPos, Name: "goto", Obj: &ast.Object{Data: label}},
 			Args:       []ast.Expr{label},
-			NoParenEnd: v.TokPos,
+			NoParenEnd: v.Label.End(),
 		}, clIdentGoto)
 	case token.BREAK:
 		ctx.cb.Break(getLabel(ctx, label))

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -904,7 +904,7 @@ func compileBranchStmt(ctx *blockCtx, v *ast.BranchStmt) {
 		compileCallExpr(ctx, &ast.CallExpr{
 			Fun:        &ast.Ident{NamePos: v.TokPos, Name: "goto", Obj: &ast.Object{Data: label}},
 			Args:       []ast.Expr{label},
-			NoParenEnd: v.Label.End(),
+			NoParenEnd: label.End(),
 		}, clIdentGoto)
 	case token.BREAK:
 		ctx.cb.Break(getLabel(ctx, label))

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -902,8 +902,9 @@ func compileBranchStmt(ctx *blockCtx, v *ast.BranchStmt) {
 			return
 		}
 		compileCallExpr(ctx, &ast.CallExpr{
-			Fun:  &ast.Ident{NamePos: v.TokPos, Name: "goto", Obj: &ast.Object{Data: label}},
-			Args: []ast.Expr{label},
+			Fun:        &ast.Ident{NamePos: v.TokPos, Name: "goto", Obj: &ast.Object{Data: label}},
+			Args:       []ast.Expr{label},
+			NoParenEnd: v.TokPos,
 		}, clIdentGoto)
 	case token.BREAK:
 		ctx.cb.Break(getLabel(ctx, label))


### PR DESCRIPTION
fix: https://github.com/goplus/builder/issues/1696